### PR TITLE
Added missing dependency for Intel platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \
 RUN pip3 install supervisord-dependent-startup==1.4.0
 
 # Install dependencies
-RUN apt-get install -y redis-server libhiredis0.14 python3-redis
+RUN apt-get install -y redis-server libhiredis0.14 python3-redis libc-ares2
 
 # Install sonic-swss-common & sonic-sairedis building dependencies
 RUN apt-get install -y \

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -33,7 +33,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \
 RUN pip3 install supervisord-dependent-startup==1.4.0
 
 # Install dependencies
-RUN apt-get install -y redis-server libhiredis0.14 python3-redis
+RUN apt-get install -y redis-server libhiredis0.14 python3-redis libc-ares2
 
 # Install sonic-swss-common & sonic-sairedis building dependencies
 RUN apt-get install -y \


### PR DESCRIPTION
- Why I did it

if build SDK with gRPC, libgrpc.so has a dependency on libcares.so. But this lib in the docker environment is absent.

- How I did it
Added missing dependency for Intel platform
- Test cases added

run: ./build.sh -a tofino -t model
