### PR TITLE
test_l2_lag fixed

### DIFF
--- a/tests/test_l2_basic.py
+++ b/tests/test_l2_basic.py
@@ -254,9 +254,6 @@ def test_l2_lag(npu, dataplane):
     9. Send packets from each of the members and check they are received on port 4 (with port 4's destination MAC)
     10. Clean up configuration
     """
-    if 'tofino' in npu.name:
-        # Skip for all Tofino NPUs
-        pytest.skip("Temporarily disabled for Tofino NPU")
 
     vlan_id = "10"
     macs = ['00:11:11:11:11:11', '00:22:22:22:22:22']
@@ -347,7 +344,6 @@ def test_l2_lag(npu, dataplane):
 
         npu.remove_vlan_member(vlan_oid, lag_bp_oid)
         npu.remove_vlan_member(vlan_oid, npu.dot1q_bp_oids[3])
-        npu.remove(vlan_oid)
 
         for oid in lag_mbr_oids:
             npu.remove(oid)
@@ -374,6 +370,7 @@ def test_l2_lag(npu, dataplane):
         for oid in npu.port_oids[0:4]:
             npu.set(oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", npu.default_vlan_id])
 
+        npu.remove(vlan_oid)
 
 def test_l2_vlan_bcast_ucast(npu, dataplane):
     """


### PR DESCRIPTION
Why I did it
tried to remove VLAN object when VLAN object has references 
How I did it
Fix sequence remove objects in the l2_lag test
Test cases added
run: docker exec -ti sai-challenger-run pytest --npu=tofino --sku=tofino_32x25g --traffic -v -k "_l2_lag"