### PR TITLE
fixed Sai:to_list for the case a list contains no items

### DIFF
--- a/common/sai.py
+++ b/common/sai.py
@@ -128,8 +128,8 @@ class SaiData:
 
     def to_list(self, idx = 1):
         value = self.to_json()[idx]
-        idx = value.index(":") + 1
-        return value[idx:].split(",")
+        n_items, _, items = value.partition(':')
+        return items.split(",") if int(n_items) > 0 else []
 
     def oids(self, idx = 1):
         value = self.to_list(idx)


### PR DESCRIPTION
In case a requested list contains no items, the returned Python list may be `[null]` instead of being empty, like for the case port list requested when no port objects configured.
Fixed by checking length of SAI list before putting items into Python list