### PR TITLE
Fixed arg for run_client_server in doc

### DIFF
--- a/docs/client_server_mode.md
+++ b/docs/client_server_mode.md
@@ -32,7 +32,7 @@ Where: _sc-server-run_ and _sc-client-run_ are docker names of SAI-Challenger se
 
 Alternatively, you can run the whole client-server environment on the same host with a single script:
 ```sh
-./run_client_server.sh start -a trident2 -t saivs
+./run_client_server.sh -a trident2 -t saivs start
 ./run_client_server.sh start
 ```
 


### PR DESCRIPTION
Signed-off-by: Taras Keryk <taras.keryk@plvision.eu>

Changed argument order in doc for run_client_server.sh.

Error due run_client_server.sh:
```
$ ./run_client_server.sh start -a trident2 -t saivs
Incorrect COMMAND provided. Allowed: start|stop
```
