### PR TITLE
Added CI to check docker images build process

### DIFF
--- a/.github/workflows/saichallenger-client-docker.yml
+++ b/.github/workflows/saichallenger-client-docker.yml
@@ -1,0 +1,109 @@
+on:
+  push:
+    branches: [ "**" ]
+    paths:
+      - '.github/workflows/saichallenger-client-docker.yml'
+      - 'dockerfiles/Dockerfile'
+      - 'dockerfiles/Dockerfile.client'
+      - 'dockerfiles/Dockerfile.saithrift-client'
+      - 'dockerfiles/Dockerfile.server'
+      - 'npu/broadcom/trident2/saivs/Dockerfile.saithrift'
+      - 'npu/broadcom/trident2/saivs/Dockerfile'
+      - 'npu/broadcom/trident2/saivs/Dockerfile.server'
+      - 'npu/intel/tofino2/model/Dockerfile'
+      - 'npu/intel/tofino2/model/Dockerfile.server'
+      - 'npu/intel/tofino/montara/Dockerfile.server'
+      - 'npu/intel/tofino/model/Dockerfile'
+      - 'npu/intel/tofino/model/Dockerfile.server'
+      - 'usecases/pins/Dockerfile'
+      - 'common/'
+      - 'builds/'
+      - 'cli/'
+      - 'scripts/'
+      - 'configs/'
+      - 'setup.py'
+      - 'build.sh'
+      - '.dockerignore'
+  pull_request:
+    branches: [ "**" ]
+    paths:
+      - '.github/workflows/saichallenger-client-docker.yml'
+      - 'dockerfiles/Dockerfile'
+      - 'dockerfiles/Dockerfile.client'
+      - 'dockerfiles/Dockerfile.saithrift-client'
+      - 'dockerfiles/Dockerfile.server'
+      - 'npu/broadcom/trident2/saivs/Dockerfile.saithrift'
+      - 'npu/broadcom/trident2/saivs/Dockerfile'
+      - 'npu/broadcom/trident2/saivs/Dockerfile.server'
+      - 'npu/intel/tofino2/model/Dockerfile'
+      - 'npu/intel/tofino2/model/Dockerfile.server'
+      - 'npu/intel/tofino/montara/Dockerfile.server'
+      - 'npu/intel/tofino/model/Dockerfile'
+      - 'npu/intel/tofino/model/Dockerfile.server'
+      - 'usecases/pins/Dockerfile'
+      - 'common/'
+      - 'builds/'
+      - 'cli/'
+      - 'scripts/'
+      - 'configs/'
+      - 'setup.py'
+      - 'build.sh'
+      - '.dockerignore'
+  workflow_dispatch:
+  
+jobs:
+  
+  build-sc-client-thrift:
+    name: Build SAI-Challenger-client-thrift-image
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: submodules update
+      run: git submodule update --init
+    - name: build docker image
+      run: |
+       ./build.sh -i client -s thrift
+  
+  build-sc-standalone:
+    name: Build SAI-Challenger-standalone-image
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: submodules update
+      run: git submodule update --init
+    - name: build docker image
+      run: |
+        ./build.sh -i standalone 
+  
+  build-sc-stadalone-thrift:
+    name: Build SAI-Challenger-standalone-thrift-image
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: submodules update
+      run: git submodule update --init
+    - name: build docker image
+      run: |
+       ./build.sh -i standalone -s thrift
+  build-sc-server:
+    name: Build SAI-Challenger-server-image
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: submodules update
+      run: git submodule update --init
+    - name: build docker image
+      run: |
+       ./build.sh -i server
+       
+  build-sc-server-thrift:
+    name: Build SAI-Challenger-server-thrift-image
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: submodules update
+      run: git submodule update --init
+    - name: build docker image
+      run: |
+       ./build.sh -i server -s thrift
+

--- a/.github/workflows/sc-docker-images-bldr.yml
+++ b/.github/workflows/sc-docker-images-bldr.yml
@@ -1,3 +1,5 @@
+name: sc-docker-images-bldr
+
 on:
   push:
     branches: [ "**" ]
@@ -54,7 +56,7 @@ on:
 jobs:
   
   build-sc-client-thrift:
-    name: Build SAI-Challenger-client-thrift-image
+    name: Build SAI Challenger client thrift image
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -65,7 +67,7 @@ jobs:
        ./build.sh -i client -s thrift
   
   build-sc-standalone:
-    name: Build SAI-Challenger-standalone-image
+    name: Build SAI Challenger standalone image
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -76,7 +78,7 @@ jobs:
         ./build.sh -i standalone 
   
   build-sc-stadalone-thrift:
-    name: Build SAI-Challenger-standalone-thrift-image
+    name: Build SAI Challenger standalone thrift image
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -85,8 +87,9 @@ jobs:
     - name: build docker image
       run: |
        ./build.sh -i standalone -s thrift
+  
   build-sc-server:
-    name: Build SAI-Challenger-server-image
+    name: Build SAI Challenger server image
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -97,7 +100,7 @@ jobs:
        ./build.sh -i server
        
   build-sc-server-thrift:
-    name: Build SAI-Challenger-server-thrift-image
+    name: Build SAI Challenger server thrift image
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -106,4 +109,3 @@ jobs:
     - name: build docker image
       run: |
        ./build.sh -i server -s thrift
-


### PR DESCRIPTION
Added CI to check build process for docker images for the main SAI-Challenger modes:

SAI-Challenger client with thrift interface:
```
./build.sh -i client -s thrift
```
SAI-Challenger in standalone mode:
```
./build.sh -i standalone
```
SAI-Challenger in standalone mode with thrift interface:
```
./build.sh -i standalone -s thrift
```
SAI-Challenger server:
```
./build.sh -i server
```
SAI-Challenger server with thrift interface:
```
./build.sh -i server -s thrift
```