### PR TITLE
Updated gen_attr_list script for generate enum dict

### DIFF
--- a/npu/broadcom/BCM56850/saivs/Dockerfile
+++ b/npu/broadcom/BCM56850/saivs/Dockerfile
@@ -44,7 +44,9 @@ RUN cd /sai/gen_attr_list \
         && cmake .. \
         && make -j$(nproc) \
         && mkdir -p /etc/sai \
-        && ./attr_list_generator > /etc/sai/sai.json
+        && ./attr_list_generator > /etc/sai/sai.json.tmp \
+        && python -mjson.tool /etc/sai/sai.json.tmp > /etc/sai/sai.json \
+        && rm /etc/sai/sai.json.tmp
 
 # Setup supervisord
 COPY configs/sai.profile       /etc/sai.d/sai.profile

--- a/npu/broadcom/BCM56850/saivs/Dockerfile.saithrift
+++ b/npu/broadcom/BCM56850/saivs/Dockerfile.saithrift
@@ -66,7 +66,9 @@ RUN cd /sai/gen_attr_list \
         && cmake .. \
         && make -j$(nproc) \
         && mkdir -p /etc/sai \
-        && ./attr_list_generator > /etc/sai/sai.json
+        && ./attr_list_generator > /etc/sai/sai.json.tmp \
+        && python -mjson.tool /etc/sai/sai.json.tmp > /etc/sai/sai.json \
+        && rm /etc/sai/sai.json.tmp
 
 # Install PTF dependencies
 RUN pip3 install pysubnettree

--- a/npu/intel/tofino/model/Dockerfile
+++ b/npu/intel/tofino/model/Dockerfile
@@ -46,7 +46,9 @@ RUN cd /sai/gen_attr_list \
         && cmake .. \
         && make -j$(nproc) \
         && mkdir -p /etc/sai \
-        && ./attr_list_generator > /etc/sai/sai.json
+        && ./attr_list_generator > /etc/sai/sai.json.tmp \
+        && python -mjson.tool /etc/sai/sai.json.tmp > /etc/sai/sai.json \
+        && rm /etc/sai/sai.json.tmp
 
 # Setup supervisord
 COPY scripts/redis_start.sh   /usr/bin/redis_start.sh

--- a/npu/intel/tofino2/model/Dockerfile
+++ b/npu/intel/tofino2/model/Dockerfile
@@ -46,7 +46,9 @@ RUN cd /sai/gen_attr_list \
         && cmake .. \
         && make -j$(nproc) \
         && mkdir -p /etc/sai \
-        && ./attr_list_generator > /etc/sai/sai.json
+        && ./attr_list_generator > /etc/sai/sai.json.tmp \
+        && python -mjson.tool /etc/sai/sai.json.tmp > /etc/sai/sai.json \
+        && rm /etc/sai/sai.json.tmp
 
 # Setup supervisord
 COPY scripts/redis_start.sh   /usr/bin/redis_start.sh

--- a/scripts/gen_attr_list/generate_attrs.cpp
+++ b/scripts/gen_attr_list/generate_attrs.cpp
@@ -157,16 +157,34 @@ nlohmann::json attribute(const sai_object_type_info_t *obj_type_info)
     return obj_info;
 }
 
+nlohmann::json enums(const sai_object_type_info_t *obj_type_info)
+{
+    nlohmann::json j;
+    auto pname = (*obj_type_info).enummetadata->valuesnames;
+    auto pvalue = (*obj_type_info).enummetadata->values;
+    while (*pname)
+    {
+        j[*pname] = *pvalue;
+        pname++;
+        pvalue++;
+    }
+
+    return j;
+}
+
 int main()
 {
     nlohmann::json json;
     const sai_object_type_info_t *const *obj_type_info = sai_metadata_all_object_type_infos;
+    std::string enum_list;
     while (*(++obj_type_info))
     {
         json.push_back(nlohmann::json{
             { "name", (*obj_type_info)->objecttypename },
             { "description", description((*obj_type_info)->objecttypename) },
-            { "attributes", attribute(*obj_type_info) } });
+            { "attributes", attribute(*obj_type_info) },
+            { "enums", enums(*obj_type_info) } });
+        enum_list.clear();
     }
     std::cout << json.dump() << std::endl;
     return 0;

--- a/scripts/gen_attr_list/generate_attrs.cpp
+++ b/scripts/gen_attr_list/generate_attrs.cpp
@@ -160,13 +160,11 @@ nlohmann::json attribute(const sai_object_type_info_t *obj_type_info)
 nlohmann::json enums(const sai_object_type_info_t *obj_type_info)
 {
     nlohmann::json j;
-    auto pname = (*obj_type_info).enummetadata->valuesnames;
-    auto pvalue = (*obj_type_info).enummetadata->values;
-    while (*pname)
+    for (size_t index = 0; index < obj_type_info->enummetadata->valuescount; index++)
     {
-        j[*pname] = *pvalue;
-        pname++;
-        pvalue++;
+        auto name = obj_type_info->enummetadata->valuesnames[index];
+        auto value = obj_type_info->enummetadata->values[index];
+        j[name] = value;
     }
 
     return j;
@@ -175,15 +173,20 @@ nlohmann::json enums(const sai_object_type_info_t *obj_type_info)
 int main()
 {
     nlohmann::json json;
+    nlohmann::json enum_values;
     const sai_object_type_info_t *const *obj_type_info = sai_metadata_all_object_type_infos;
     std::string enum_list;
     while (*(++obj_type_info))
     {
+        if ((*obj_type_info)->enummetadata->valuescount)
+        {
+            enum_values = enums(*obj_type_info);
+        }
         json.push_back(nlohmann::json{
             { "name", (*obj_type_info)->objecttypename },
             { "description", description((*obj_type_info)->objecttypename) },
             { "attributes", attribute(*obj_type_info) },
-            { "enums", enums(*obj_type_info) } });
+            { "values",  enum_values } });
         enum_list.clear();
     }
     std::cout << json.dump() << std::endl;


### PR DESCRIPTION
Added "enums" attribute. 
Part of sai.json example: 

```
        "attributes": [
            {
                "name": "SAI_TABLE_BITMAP_ROUTER_ENTRY_ATTR_ACTION",
                "properties": {
                    "description": "Action.",
                    "flags": [
                        "MANDATORY_ON_CREATE",
                        "CREATE_ONLY"
                    ],
                    "type": "sai_int32_t",
                    "values": {
                        "SAI_TABLE_BITMAP_ROUTER_ENTRY_ACTION_DROP": 3,
                        "SAI_TABLE_BITMAP_ROUTER_ENTRY_ACTION_NOACTION": 4,
                        "SAI_TABLE_BITMAP_ROUTER_ENTRY_ACTION_TO_CPU": 2,
                        "SAI_TABLE_BITMAP_ROUTER_ENTRY_ACTION_TO_LOCAL": 1,
                        "SAI_TABLE_BITMAP_ROUTER_ENTRY_ACTION_TO_NEXTHOP": 0
                    }
                }
            },

   . . . . . 
```