### PR TITLE
Extended Bulk APIs to support OID-based objects

### DIFF
--- a/common/sai.py
+++ b/common/sai.py
@@ -219,15 +219,15 @@ class Sai():
     def get(self, obj, attrs, do_assert=True):
         return self.sai_client.get(obj, attrs, do_assert)
 
-    # BULK (TODO remove do_assert, "oid:" and handle oid
-    def bulk_create(self, obj, keys, attrs, do_assert=True):
-        return self.sai_client.bulk_create(obj, keys, attrs, do_assert)
+    # BULK
+    def bulk_create(self, obj_type, keys, attrs, obj_count=0, do_assert=True):
+        return self.sai_client.bulk_create(obj_type, keys, attrs, obj_count, do_assert)
 
-    def bulk_remove(self, obj, keys, do_assert=True):
-        return self.sai_client.bulk_remove(obj, keys, do_assert)
+    def bulk_remove(self, obj_type, keys, do_assert=True):
+        return self.sai_client.bulk_remove(obj_type, keys, do_assert)
 
-    def bulk_set(self, obj, keys, attrs, do_assert=True):
-        return self.sai_client.bulk_set(obj, keys, attrs, do_assert)
+    def bulk_set(self, obj_type, keys, attrs, do_assert=True):
+        return self.sai_client.bulk_set(obj_type, keys, attrs, do_assert)
 
     # Stats
     def get_stats(self, obj, attrs, do_assert=True):

--- a/common/sai_client/sai_client.py
+++ b/common/sai_client/sai_client.py
@@ -59,13 +59,13 @@ class SaiClient:
         raise NotImplementedError
 
     # BULK
-    def bulk_create(self, obj, keys, attrs, do_assert=True):
+    def bulk_create(self, obj_type, keys, attrs, obj_count=0, do_assert=True):
         raise NotImplementedError
 
-    def bulk_remove(self, obj, keys, do_assert=True):
+    def bulk_remove(self, obj_type, keys, do_assert=True):
         raise NotImplementedError
 
-    def bulk_set(self, obj, keys, attrs, do_assert=True):
+    def bulk_set(self, obj_type, keys, attrs, do_assert=True):
         raise NotImplementedError
 
     # Host interface


### PR DESCRIPTION
Extended Bulk APIs to support OID-based objects.

The `bulk_create()` API has been extended with one new parameter `obj_count`.
BEFORE
```
bulk_create(self, obj, keys, attrs, do_assert=True):
```
AFTER
```
bulk_create(self, obj_type, keys, attrs, obj_count=0, do_assert=True):
```

On key-based objects creation (FDB, route, etc), `obj_count` will be ignored because `keys` provides the list of keys to be created.
On OID-based objects creation, `keys` must be `None` and `obj_count` defines the number of objects to be created.