### PR TITLE
Bring-up of sairedis.rec on top of Thrift API

### DIFF
--- a/.github/workflows/sc-docker-standalone-bldr.yml
+++ b/.github/workflows/sc-docker-standalone-bldr.yml
@@ -55,3 +55,5 @@ jobs:
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_l2_basic_dd.py
     - name: Run thrift unit tests
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v ut/test_vrf_ut.py ut/test_bridge_ut.py
+    - name: Run thrift sairedis tests
+      run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v -k "test_sairec"

--- a/common/sai_client/sai_client.py
+++ b/common/sai_client/sai_client.py
@@ -14,9 +14,6 @@ class SaiClient:
     def set_loglevel(self, sai_api, loglevel):
         raise NotImplementedError
 
-    def alloc_vid(self, obj_type):
-        raise NotImplementedError
-
     # CRUD
     def create(self, obj, attrs, do_assert=True):
         """

--- a/common/sai_client/sai_thrift_client/sai_thrift_client.py
+++ b/common/sai_client/sai_thrift_client/sai_thrift_client.py
@@ -178,7 +178,7 @@ class SaiThriftClient(SaiClient):
         result = []
 
         for attr, value in ThriftConverter.convert_attributes_to_thrift(attrs):
-            if obj_type_name != "switch":
+            if key is None and obj_type_name != "switch":
                 object_key = {obj_type_name + "_oid": oid}
 
             # The function parameter can not start from digit.
@@ -225,16 +225,20 @@ class SaiThriftClient(SaiClient):
         out_keys = []
         entries_num = len(keys) if keys else obj_count
         statuses = [None] * entries_num
+
+        if type(obj_type) == SaiObjType:
+            obj_type = "SAI_OBJECT_TYPE_" + obj_type.name
+
         for i in range(entries_num):
             attr = attrs[0] if len(attrs) == 1 else attrs[i]
             if do_assert == False:
-                status, vid = self.create("SAI_OBJECT_TYPE_" + obj_type.name + ":" + json.dumps(keys[i]), attr, do_assert)
+                status, vid = self.create(obj_type + ":" + json.dumps(keys[i]), attr, do_assert)
                 out_keys.append(vid)
                 statuses.append(status)
                 if status != "SAI_STATUS_SUCCESS":
                     return "SAI_STATUS_FAILURE", out_keys, statuses
             else:
-                vid = self.create("SAI_OBJECT_TYPE_" + obj_type.name + ":" + json.dumps(keys[i]), attr, do_assert)
+                vid = self.create(obj_type + ":" + json.dumps(keys[i]), attr, do_assert)
                 out_keys.append(vid)
                 statuses.append("SAI_STATUS_SUCCESS")
         return "SAI_STATUS_SUCCESS", out_keys, statuses
@@ -242,28 +246,36 @@ class SaiThriftClient(SaiClient):
     def bulk_remove(self, obj_type, keys, do_assert=True):
         # TODO: Provide proper implementation once Thrift bulk API is available
         statuses = [None] * len(keys)
+
+        if type(obj_type) == SaiObjType:
+            obj_type = "SAI_OBJECT_TYPE_" + obj_type.name
+
         for key in keys:
             if do_assert == False:
-                status, _ = self.remove("SAI_OBJECT_TYPE_" + obj_type.name + ":" + json.dumps(key), do_assert)
+                status, _ = self.remove(obj_type + ":" + json.dumps(key), do_assert)
                 statuses.append(status)
                 if status != "SAI_STATUS_SUCCESS":
                     return "SAI_STATUS_FAILURE", statuses
             else:
-                self.remove("SAI_OBJECT_TYPE_" + obj_type.name + ":" + json.dumps(key), do_assert)
+                self.remove(obj_type + ":" + json.dumps(key), do_assert)
         return "SAI_STATUS_SUCCESS", statuses
 
     def bulk_set(self, obj_type, keys, attrs, do_assert=True):
         # TODO: Provide proper implementation once Thrift bulk API is available
         statuses = [None] * len(keys)
+
+        if type(obj_type) == SaiObjType:
+            obj_type = "SAI_OBJECT_TYPE_" + obj_type.name
+
         for i in range(len(keys)):
             attr = attrs[0] if len(attrs) == 1 else attrs[i]
             if do_assert == False:
-                status, _ = self.set("SAI_OBJECT_TYPE_" + obj_type.name + ":" + json.dumps(keys[i]), attr, do_assert)
+                status, _ = self.set(obj_type + ":" + json.dumps(keys[i]), attr, do_assert)
                 statuses.append(status)
                 if status != "SAI_STATUS_SUCCESS":
                     return "SAI_STATUS_FAILURE", statuses
             else:
-                self.set("SAI_OBJECT_TYPE_" + obj_type.name + ":" + json.dumps(keys[i]), attr, do_assert)
+                self.set(obj_type + ":" + json.dumps(keys[i]), attr, do_assert)
         return "SAI_STATUS_SUCCESS", statuses
 
     def get_object_key(self, obj_type=None):

--- a/common/sai_client/sai_thrift_client/sai_thrift_utils.py
+++ b/common/sai_client/sai_thrift_client/sai_thrift_utils.py
@@ -71,7 +71,7 @@ class ThriftConverter():
                 actual_value = getattr(sai_headers, value, None)
                 if actual_value != None:
                     return actual_value
-            return 0 if value == '' else int(value)
+            return 0 if value == '' else int(value, 0)
         if value_type in [ 'booldata' ]:
             return value.lower() == "true" or value == "0"
         elif value_type in [ 'mac', 'ipv4', 'ipv6', 'chardata' ]:
@@ -242,12 +242,12 @@ class ThriftConverter():
 
         if '.' in prefix_str:
             family = SAI_IP_ADDR_FAMILY_IPV4
-            ip = ipaddress.IPv4Network(prefix_str)
+            ip = ipaddress.IPv4Network(prefix_str, strict=False)
             addr = sai_thrift_ip_addr_t(ip4=str(ip.network_address))
             mask = sai_thrift_ip_addr_t(ip4=str(ip.netmask))
         elif ':' in prefix_str:
             family = SAI_IP_ADDR_FAMILY_IPV6
-            ip = ipaddress.IPv6Network(prefix_str)
+            ip = ipaddress.IPv6Network(prefix_str, strict=False)
             addr = sai_thrift_ip_addr_t(ip6=ip.network_address.exploded)
             mask = sai_thrift_ip_addr_t(ip6=ip.netmask.exploded)
         else:


### PR DESCRIPTION
```
root@b2cb2e0f8edf:/sai-challenger/tests# pytest --testbed=saivs_thrift_standalone -v -k "sairec"
=========================================================================================== test session starts ===========================================================================================

test_sairec.py::test_apply_sairec[BCM56850/empty_sw.rec] PASSED                                                                                                                                     [  9%]
test_sairec.py::test_apply_sairec[BCM56850/bridge_create_1.rec] PASSED                                                                                                                              [ 18%]
test_sairec.py::test_apply_sairec[BCM56850/hostif.rec] PASSED                                                                                                                                       [ 27%]
test_sairec.py::test_apply_sairec[BCM56850/acl_tables.rec] PASSED                                                                                                                                   [ 36%]
test_sairec.py::test_apply_sairec[BCM56850/bulk_fdb.rec] PASSED                                                                                                                                     [ 45%]
test_sairec.py::test_apply_sairec[BCM56850/bulk_route.rec] PASSED                                                                                                                                   [ 54%]
test_sairec.py::test_apply_sairec[BCM56850/remove_create_port.rec] PASSED                                                                                                                           [ 63%]
test_sairec.py::test_trident3_scenario[t1_factory_default.rec] SKIPPED (Trident3 specific scenario)                                                                                                 [ 72%]
test_sairec.py::test_tofino_scenario[t0_full.rec] SKIPPED (Tofino specific scenario)                                                                                                                [ 81%]
test_sairec.py::test_tofino_scenario[t1_full.rec] SKIPPED (Tofino specific scenario)                                                                                                                [ 90%]
test_sairec.py::test_tofino_scenario[t1_lag_full.rec] SKIPPED (Tofino specific scenario)                                                                                                            [100%]

============================================================================== 7 passed, 4 skipped, 557 deselected in 20.51s ==============================================================================
```