### PR TITLE
Implemented conversion for 'qosmap' into Thrift format

### DIFF
--- a/common/sai_client/sai_redis_client/sai_redis_client.py
+++ b/common/sai_client/sai_redis_client/sai_redis_client.py
@@ -135,7 +135,11 @@ class SaiRedisClient(SaiClient):
             vid = json.loads(obj.split(":", 1)[1])
 
         if type(attrs) != str:
+            for i, attr in enumerate(attrs):
+                if type(attr) != str:
+                    attrs[i] = json.dumps(attr)
             attrs = json.dumps(attrs)
+
         status = self.operate(obj, attrs, "Screate")
         status[2] = status[2].decode("utf-8")
         if do_assert:


### PR DESCRIPTION
Related sairedis implementation:
https://github.com/sonic-net/sonic-sairedis/blob/c1d8a8b60a3eefcf2b89fd00d225709cf016d467/meta/SaiSerialize.cpp#L2688

sairedis.rec representation
```
SAI_QOS_MAP_ATTR_MAP_TO_VALUE_LIST={"count":1,"list":[{"key":{"color":"SAI_PACKET_COLOR_GREEN","dot1p":0,"dscp":0,"pg":0,"prio":0,"qidx":0,"tc":0},"value":{"color":"SAI_PACKET_COLOR_GREEN","dot1p":0,"dscp":0,"pg":0,"prio":0,"qidx":0,"tc":0}}]}
```
As a result, the configuration can be provided either in dict format:
```
            {
                'name': 'qos_map_1',
                'op': 'create',
                'type': 'SAI_OBJECT_TYPE_QOS_MAP',
                'attributes': [
                    'SAI_QOS_MAP_ATTR_TYPE',
                    'SAI_QOS_MAP_TYPE_DOT1P_TO_TC',
                    'SAI_QOS_MAP_ATTR_MAP_TO_VALUE_LIST',
                    {
                        "count":1,
                        "list":[
                            {
                                "key":{"color":"SAI_PACKET_COLOR_GREEN","dot1p":0,"dscp":0,"pg":0,"prio":0,"qidx":0,"tc":0},
                                "value":{"color":"SAI_PACKET_COLOR_GREEN","dot1p":0,"dscp":0,"pg":0,"prio":0,"qidx":0,"tc":0}
                            }
                        ]
                    }
                ],
            }
```
or in string format
```
            {
                'name': 'qos_map_1',
                'op': 'create',
                'type': 'SAI_OBJECT_TYPE_QOS_MAP',
                'attributes': [
                    'SAI_QOS_MAP_ATTR_TYPE',
                    'SAI_QOS_MAP_TYPE_DOT1P_TO_TC',
                    'SAI_QOS_MAP_ATTR_MAP_TO_VALUE_LIST',
                    '{"count":1,"list":[{"key":{"color":"SAI_PACKET_COLOR_GREEN","dot1p":0,"dscp":0,"pg":0,"prio":0,"qidx":0,"tc":0},"value":{"color":"SAI_PACKET_COLOR_GREEN","dot1p":0,"dscp":0,"pg":0,"prio":0,"qidx":0,"tc":0}}]}'
                ],
            }

```
