### PR TITLE
Updated process_command() to be able to get multiple attrs

### DIFF
--- a/common/sai.py
+++ b/common/sai.py
@@ -143,7 +143,14 @@ class CommandProcessor:
                     del self.objects_registry[store_name]
 
         elif operation == "get":
-            return self.sai.get(obj_id, attrs)
+            obj_type = self.sai.vid_to_type(obj_id)
+            results = []
+            for attr in attrs:
+                attr_type = self.sai.get_obj_attr_type(obj_type, attr)
+                status, data = self.sai.get_by_type(obj_id, attr, attr_type)
+                assert status == "SAI_STATUS_SUCCESS", f"Failed to retrieve {attr}: {status}"
+                results.append(data)
+            return results
 
         elif operation == "set":
             return self.sai.set(obj_id, attrs)

--- a/tests/test_l2_basic_dd.py
+++ b/tests/test_l2_basic_dd.py
@@ -72,19 +72,18 @@ def test_l2_trunk_to_trunk_vlan_dd(npu, dataplane):
             "name": "vlan_10",
             "op": "get",
             "attributes": [
-                "SAI_VLAN_ATTR_MAX_LEARNED_ADDRESSES", ""
+                "SAI_VLAN_ATTR_MAX_LEARNED_ADDRESSES",
+                "SAI_VLAN_ATTR_MEMBER_LIST"
             ]
-        },
-        {
-            "name": "vlan_10",
-            "op": "get",
-            "attributes": ["SAI_VLAN_ATTR_MEMBER_LIST", "2:oid:0x0,oid:0x0"]
         }
     ]
     status = [*npu.process_commands(cmds2)]
+    # command #0
     assert status[0] == "SAI_STATUS_SUCCESS"
-    assert status[1].value() == vlan_learned_max
-    assert len(status[2].oids()) == 2
+    # command #1, attribute #0
+    assert status[1][0].value() == vlan_learned_max
+    # command #1, attribute #1
+    assert len(status[1][1].oids()) == 2
 
     try:
         if npu.run_traffic:


### PR DESCRIPTION
Improvement in scope of https://github.com/opencomputeproject/SAI-Challenger/issues/101 request.
This also affects https://github.com/opencomputeproject/SAI-Challenger/issues/99.

To retrieve multiple attributes of a single SAI object:
```
cmd =  [
        {
            "name": "vlan_10",
            "op": "get",
            "attributes": [
                "SAI_VLAN_ATTR_MAX_LEARNED_ADDRESSES",
                "SAI_VLAN_ATTR_MEMBER_LIST"
            ]
        }
    ]
```
To access the returned values:
```
    status = [*npu.process_commands(cmd)]
    # command #0, attribute #0
    assert status[0][0].value() == "512"
    # command #0, attribute #1
    assert len(status[0][1].oids()) == 2
```