### PR TITLE
Fix for running CI tests in DASH

### DIFF
--- a/common/sai_dpu.py
+++ b/common/sai_dpu.py
@@ -28,7 +28,7 @@ class SaiDpu(Sai):
                                          ["SAI_SWITCH_ATTR_DEFAULT_VLAN_ID", "oid:0x0"]).oid()
         logging.info(f'Default VLAN oid {self.default_vlan_oid}')
 
-        port_num = self.get(self.switch_oid, ["SAI_SWITCH_ATTR_NUMBER_OF_ACTIVE_PORTS", 0]).uint32()
+        port_num = self.get(self.switch_oid, ["SAI_SWITCH_ATTR_NUMBER_OF_ACTIVE_PORTS", ""]).uint32()
         if port_num > 0:
             self.port_oids = self.get(self.switch_oid,
                                       ["SAI_SWITCH_ATTR_PORT_LIST", self.make_list(port_num, "oid:0x0")]).oids()


### PR DESCRIPTION
Fixed run CI tests in DASH pipeline. 

Problem was:
./run-tests.sh --setup=sai_dpu_client_server_snappi.json test_vm_to_vm_commn_acl_outbound.py -k TestAclOutbound -rP
```
E           TypeError: int() can't convert non-string with explicit base

/usr/local/lib/python3.7/dist-packages/saichallenger/common/sai_client/sai_thrift_client/sai_thrift_utils.py:79: TypeError
=================================================== 2 skipped, 1 error in 0.25s ======================
```
