### PR TITLE
Remove .build directory from previous unsuccessful build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -65,6 +65,9 @@ if [[ "${IMAGE_TYPE}" != "standalone" && \
     exit 1
 fi
 
+# Clean the previous build
+rm -rf .build/
+
 if [[ "${IMAGE_TYPE}" != "client" ]]; then
 
     if [ -z "${ASIC_TYPE}" ]; then


### PR DESCRIPTION
After building docker with parameters:
```
./build.sh -i server -a BCM81724 -t saivs
```
want to run docker with the same parameters and have an error:
```
./run.sh -i server -a BCM81724 -t saivs
docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
ERROR: "docker run --name sc-server-${ASIC_TYPE}-${TARGET}-run --cap-add=NET_ADMIN ${OPTS} --device /dev/net/tun:/dev/net/tun -d sc-server-${ASIC_TYPE}-${TARGET}" command filed with exit code 125.
```
This fix allows to use lowercase or uppercase letters for docker image naming