### PR TITLE
Fixed testbed name access issue

### DIFF
--- a/tests/phy/ut/test_phy_port_ut.py
+++ b/tests/phy/ut/test_phy_port_ut.py
@@ -11,7 +11,7 @@ port_attrs_updated = {}
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.phy) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 @pytest.fixture(scope="module")

--- a/tests/phy/ut/test_phy_switch_ut.py
+++ b/tests/phy/ut/test_phy_switch_ut.py
@@ -8,7 +8,7 @@ switch_attrs = Sai.get_obj_attrs("SAI_OBJECT_TYPE_SWITCH")
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.phy) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dc_t1.py
+++ b/tests/test_dc_t1.py
@@ -8,7 +8,7 @@ import saichallenger.topologies.dc_t1
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_l2_basic.py
+++ b/tests/test_l2_basic.py
@@ -9,7 +9,7 @@ from ptf.testutils import simple_tcp_packet, send_packet, verify_packets, verify
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 @pytest.fixture(autouse=True)
 def on_prev_test_failure(prev_test_failed, npu):

--- a/tests/test_sairec.py
+++ b/tests/test_sairec.py
@@ -6,7 +6,7 @@ import time
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -5,7 +5,7 @@ import pytest
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 def test_stats(npu, dataplane):

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -9,7 +9,7 @@ from ptf.testutils import simple_tcp_packet, send_packet, verify_packets, verify
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 def test_default_vrf(npu, dataplane):

--- a/tests/ut/test_acl_ut.py
+++ b/tests/ut/test_acl_ut.py
@@ -6,7 +6,7 @@ from saichallenger.common.sai_data import SaiObjType
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 @pytest.fixture(scope="class")

--- a/tests/ut/test_bridge_ut.py
+++ b/tests/ut/test_bridge_ut.py
@@ -6,7 +6,7 @@ from saichallenger.common.sai_data import SaiObjType
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 bport_attrs = [

--- a/tests/ut/test_hostif_ut.py
+++ b/tests/ut/test_hostif_ut.py
@@ -7,7 +7,7 @@ from saichallenger.common.sai_dataplane.utils.ptf_testutils import simple_tcp_pa
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 @pytest.fixture(scope="module")

--- a/tests/ut/test_port_ut.py
+++ b/tests/ut/test_port_ut.py
@@ -11,7 +11,7 @@ port_attrs_updated = {}
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 @pytest.fixture(scope="module")

--- a/tests/ut/test_switch_ut.py
+++ b/tests/ut/test_switch_ut.py
@@ -8,7 +8,7 @@ switch_attrs = Sai.get_obj_attrs("SAI_OBJECT_TYPE_SWITCH")
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/test_vlan_ut.py
+++ b/tests/ut/test_vlan_ut.py
@@ -8,7 +8,7 @@ TEST_VLAN_ID = "100"
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 @pytest.fixture(scope="module")

--- a/tests/ut/test_vrf_ut.py
+++ b/tests/ut/test_vrf_ut.py
@@ -9,7 +9,7 @@ switch_attrs = Sai.get_obj_attrs("SAI_OBJECT_TYPE_VIRTUAL_ROUTER")
 def skip_all(testbed_instance):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
-        pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixed the issue as follows:
```
./exec.sh pytest -v --testbed=saivs_standalone -k "port_ut"
```
```
    @pytest.fixture(scope="module", autouse=True)
    def skip_all(testbed_instance):
        testbed = testbed_instance
        if testbed is not None and len(testbed.phy) != 1:
>           pytest.skip("invalid for \"{}\" testbed".format(testbed.meta.name))
E           AttributeError: 'SaiTestbedMeta' object has no attribute 'name'

phy/ut/test_phy_port_ut.py:14: AttributeError
```