### PR TITLE
upgrade to snappi 0.11.14

### DIFF
--- a/dockerfiles/Dockerfile.client
+++ b/dockerfiles/Dockerfile.client
@@ -62,7 +62,7 @@ RUN git clone https://github.com/opencomputeproject/SAI.git \
 RUN pip3 install pytest pytest_dependency pytest-html pdbpp macaddress click==8.0
 
 # Install snappi
-RUN pip3 install snappi==0.9.8 snappi_ixnetwork==0.9.1
+RUN pip3 install snappi==0.11.14 snappi_ixnetwork==0.9.1
 
 # Install PTF dependencies
 RUN pip3 install scapy dpkt

--- a/docs/sai_dataplane.md
+++ b/docs/sai_dataplane.md
@@ -36,7 +36,7 @@ Where `port_groups` contain two ports: "veth1" and "veth2".
     "alias": "tg",
     "type": "snappi",
     "mode": "ixia_c",
-    "controller": "https://127.0.0.1:443",
+    "controller": "https://127.0.0.1:8443",
     "port_groups": [
       {"alias": 0, "name": "veth1", "speed": "10G"},
       {"alias": 1, "name": "veth2", "speed": "10G"}

--- a/testbeds/snappi_bmv2_client_server.json
+++ b/testbeds/snappi_bmv2_client_server.json
@@ -22,7 +22,7 @@
     "alias": "tg",
     "type": "snappi",
     "mode": "ixia_c",
-    "controller": "https://127.0.0.1:443",
+    "controller": "https://127.0.0.1:8443",
     "port_groups": [
       {"alias": 0, "name": "veth1", "speed": "10G"},
       {"alias": 1, "name": "veth2", "speed": "10G"}

--- a/testbeds/snappi_saivs_client_server.json
+++ b/testbeds/snappi_saivs_client_server.json
@@ -21,7 +21,7 @@
     "alias": "tg",
     "type": "snappi",
     "mode": "ixia_c",
-    "controller": "https://127.0.0.1:443",
+    "controller": "https://127.0.0.1:8443",
     "port_groups": [
       {"alias": 0, "name": "veth1", "speed": "10G"},
       {"alias": 1, "name": "veth2", "speed": "10G"}


### PR DESCRIPTION
- Upgrade snappi python client to 0.11.14 to support new ixiac controller ver 0.0.1-4064, which removes TLS 1.0 and 1.1 for security reasons (was flagged by MSFT in https://github.com/sonic-net/DASH/issues/357)
- Change client connection to ixia-c controller from port 443 to 8443, which is new default for the controller

**Note, any test fixtures need to utilize correct version of ixia-c controller and ixia-c traffic engines in your test fixtures.** This change only modifies the snappi library and connection port in SAI-Challenger. See [snappi/ixia-c release notes](https://github.com/open-traffic-generator/ixia-c/releases/tag/v0.0.1-4064) for details.

This change is required to be pulled into DASH as a submodule in order to resolve [#357](https://github.com/sonic-net/DASH/issues/357)

Note, some deprecation warnings will result from API changes in snappi. These can be seen when running DASH tests, for example see below. These should be migrated inside SAIChallenger as time allows.
>[WARNING]: set_capture_state api is deprecated, Please use `set_control_state` with `port.capture` choice instead
[WARNING]: CaptureState is deprecated, Please use `StatePortCapture` instead
