### PR TITLE
Wait upto 120sec on switch init

### DIFF
--- a/common/sai_client/sai_redis_client/sai_redis_client.py
+++ b/common/sai_client/sai_redis_client/sai_redis_client.py
@@ -109,8 +109,8 @@ class SaiRedisClient(SaiClient):
         status = []
         attempts = self.attempts
 
-        # Wait upto 3 mins for switch init on HW
-        if not self.libsaivs and obj.startswith("SAI_OBJECT_TYPE_SWITCH") and op == "Screate":
+        # Wait upto 3 mins for switch init
+        if obj.startswith("SAI_OBJECT_TYPE_SWITCH") and op == "Screate":
             tout = 0.5
             attempts = 240
 


### PR DESCRIPTION
Wait upto 120sec on switch init for both HW and saivs. This is done to avoid different behavior of `operate` API in different environments.