### PR TITLE
Introduced SONiC DUT restore mode

### DIFF
--- a/common/sai_testbed.py
+++ b/common/sai_testbed.py
@@ -188,6 +188,9 @@ class SaiTestbed():
             for dp in self.dataplane:
                 dp.deinit()
 
+        for dut in self.dut:
+            dut.deinit()
+
     def setup(self):
         """
         per testcase setup

--- a/testbeds/saivs_sonic.json
+++ b/testbeds/saivs_sonic.json
@@ -9,7 +9,7 @@
     "client": {
       "type": "redis",
       "config": {
-        "mode": "sonic",
+        "mode": "sonic-restore",
         "username": "admin",
         "password": "YourPaSsWoRd",
         "ip": "192.168.122.178",


### PR DESCRIPTION
In Redis client `sonic` mode of operation, before tests execution, SAI-C disables all SONiC services except `database` and `syncd`. SAI-C does not restore SONiC state after tests execution:
```
    "client": {
      "type": "redis",
      "config": {
        "mode": "sonic",
        "username": "admin",
        "password": "YourPaSsWoRd",
        "ip": "192.168.122.178",
        "port": "6379",
        "loglevel": "NOTICE"
      }
    }
```

This PR introduces new Redis client mode `sonic-restore`. In this mode, SAI-C will restore SONiC state after tests execution.

```
    "client": {
      "type": "redis",
      "config": {
        "mode": "sonic-restore",
        "username": "admin",
        "password": "YourPaSsWoRd",
        "ip": "192.168.122.178",
        "port": "6379",
        "loglevel": "NOTICE"
      }
    }
```

TODO: Update README.