### PR TITLE
Added --nosnappi build option

### DIFF
--- a/.github/workflows/sc-client-server-deb10.yml
+++ b/.github/workflows/sc-client-server-deb10.yml
@@ -47,9 +47,9 @@ jobs:
     - name: Update submodules
       run: git submodule update --init
     - name: Build client Docker image
-      run: ./build.sh -i client -o deb10
+      run: ./build.sh -i client -o deb10 --nosnappi
     - name: Build client Docker image with SAI thrift
-      run: ./build.sh -i client -s thrift -o deb10
+      run: ./build.sh -i client -s thrift -o deb10 --nosnappi
     - name: Save client Docker image
       run: docker save sc-client > sc-client.tar
     - name: Upload client Docker image

--- a/.github/workflows/sc-client-server-deb11.yml
+++ b/.github/workflows/sc-client-server-deb11.yml
@@ -47,9 +47,9 @@ jobs:
     - name: Update submodules
       run: git submodule update --init
     - name: Build client Docker image
-      run: ./build.sh -i client -o deb11
+      run: ./build.sh -i client -o deb11 --nosnappi
     - name: Build client Docker image with SAI thrift
-      run: ./build.sh -i client -s thrift -o deb11
+      run: ./build.sh -i client -s thrift -o deb11 --nosnappi
     - name: Save client Docker image
       run: docker save sc-client > sc-client.tar
     - name: Upload client Docker image

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,7 @@ ASIC_PATH=""
 TARGET=""
 SAI_INTERFACE="redis"
 BASE_OS="buster"
+NOSNAPPI=""
 
 declare -A base_os_map
 base_os_map["deb10"]="buster"
@@ -37,6 +38,8 @@ print-help() {
     echo "     SAI interface"
     echo "  -o [buster|bullseye]"
     echo "     Docker image base OS"
+    echo "  --nosnappi"
+    echo "     Do not include snappi to the final image"
     echo
     exit 0
 }
@@ -67,6 +70,9 @@ while [[ $# -gt 0 ]]; do
         "-o"|"--base_os")
             BASE_OS="$2"
             shift
+        ;;
+        "--nosnappi")
+            NOSNAPPI="y"
         ;;
     esac
     shift
@@ -146,7 +152,7 @@ elif [ "${IMAGE_TYPE}" = "server" ]; then
     docker build -f dockerfiles/${BASE_OS}/Dockerfile.server -t sc-server-base:${BASE_OS} .
     rm -rf .build/
 else
-    docker build -f dockerfiles/${BASE_OS}/Dockerfile.client -t sc-client:${BASE_OS} .
+    docker build -f dockerfiles/${BASE_OS}/Dockerfile.client --build-arg NOSNAPPI=${NOSNAPPI} -t sc-client:${BASE_OS} .
     if [ "${SAI_INTERFACE}" = "thrift" ]; then
         docker build -f dockerfiles/${BASE_OS}/Dockerfile.saithrift-client -t sc-thrift-client:${BASE_OS} .
     fi

--- a/dockerfiles/bullseye/Dockerfile.client
+++ b/dockerfiles/bullseye/Dockerfile.client
@@ -60,8 +60,10 @@ RUN git clone https://github.com/opencomputeproject/SAI.git \
 # Install SAI-C dependencies
 RUN pip3 install pytest pytest_dependency pytest-html aenum pdbpp macaddress click==8.0
 
-# Install snappi
-RUN pip3 install snappi==0.11.14 snappi_ixnetwork==0.9.1
+ARG NOSNAPPI
+RUN if [ "$NOSNAPPI" != "y" ]; then \
+        pip3 install snappi==0.11.14 snappi_ixnetwork==0.9.1 ; \
+    fi
 
 # Install PTF dependencies
 RUN pip3 install scapy dpkt

--- a/dockerfiles/buster/Dockerfile.client
+++ b/dockerfiles/buster/Dockerfile.client
@@ -66,8 +66,10 @@ RUN git clone https://github.com/opencomputeproject/SAI.git \
 # Install SAI-C dependencies
 RUN pip3 install pytest pytest_dependency pytest-html aenum pdbpp macaddress click==8.0
 
-# Install snappi
-RUN pip3 install snappi==0.11.14 snappi_ixnetwork==0.9.1
+ARG NOSNAPPI
+RUN if [ "$NOSNAPPI" != "y" ]; then \
+        pip3 install snappi==0.11.14 snappi_ixnetwork==0.9.1 ; \
+    fi
 
 # Install PTF dependencies
 RUN pip3 install scapy dpkt


### PR DESCRIPTION
The snappi libraries almost double SAI-C client image (826M vs 1340M). Since we do not use snappi dataplane during CI/CD, excluding snappi packages from the build.