### PR TITLE
Adding testcase that does create and remove operation for switch_tunnel object

### DIFF
--- a/tests/api/test_switch_tunnel.py
+++ b/tests/api/test_switch_tunnel.py
@@ -1,0 +1,33 @@
+from pprint import pprint
+
+
+class TestSaiSwitchTunnel:
+    # object with no parents
+
+    def test_switch_tunnel_create(self, npu):
+        commands = [
+            {
+                'name': 'switch_tunnel_1',
+                'op': 'create',
+                'type': 'SAI_OBJECT_TYPE_SWITCH_TUNNEL',
+                'attributes': [
+                    'SAI_SWITCH_TUNNEL_ATTR_TUNNEL_TYPE',
+                    'SAI_TUNNEL_TYPE_IPINIP',
+                ],
+            }
+        ]
+
+        results = [*npu.process_commands(commands)]
+        print('======= SAI commands RETURN values create =======')
+        pprint(results)
+        assert all(results), 'Create error'
+
+    def test_switch_tunnel_remove(self, npu):
+        commands = [{'name': 'switch_tunnel_1', 'op': 'remove'}]
+
+        results = [*npu.process_commands(commands)]
+        print('======= SAI commands RETURN values remove =======')
+        pprint(results)
+        assert all(
+            [result == 'SAI_STATUS_SUCCESS' for result in results]
+        ), 'Remove error'


### PR DESCRIPTION
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Contributing SAI test cases that qualifies the SAI apis. This PR consists of test cases that does create and remove operation on the API.
The cases have been validated to be passing on:


Sonic Version: SONiC.master.182904-b774ebfdc, 
HwSKU: Accton-AS7726-32X
ASIC: broadcom
SAI-Challenger Version: 2241a1a9c6a42c6b6dd474438deffec1d7d208f0
