### PR TITLE
Added support for string SAI_NULL_OBJECT_ID

### DIFF
--- a/common/sai_client/sai_thrift_client/sai_thrift_utils.py
+++ b/common/sai_client/sai_thrift_client/sai_thrift_utils.py
@@ -362,7 +362,7 @@ class ThriftConverter():
         "16"       => 16
         "oid:0x10" => 16
         """
-        if oid == None or oid == 'null':
+        if oid == None or oid == 'null' or oid == 'SAI_NULL_OBJECT_ID':
             return 0
         if isinstance(oid, str) and oid.startswith('oid:0x'):
             return int(oid[4:], 16)


### PR DESCRIPTION
Currently 0 and 'null' are treated as null, but SAI_NULL_OBJECT_ID is also valid  and it should be seen as null and not processed as int of a string 