### PR TITLE
Fixed set_sku_mode()

### DIFF
--- a/common/sai_npu.py
+++ b/common/sai_npu.py
@@ -212,9 +212,8 @@ class SaiNpu(Sai):
                 self.remove(oid)
             self.remove(self.dot1q_bp_oids[idx])
             status, data = self.get(self.port_oids[idx], ["SAI_PORT_ATTR_PORT_SERDES_ID"], do_assert=False)
-            serdes_oid = data.oid()
-            if status == "SAI_STATUS_SUCCESS" and serdes_oid != "oid:0x0":
-                self.remove(serdes_oid)
+            if status == "SAI_STATUS_SUCCESS" and data.oid() != "oid:0x0":
+                self.remove(data.oid())
             self.remove(self.port_oids[idx])
         self.port_oids.clear()
         self.dot1q_bp_oids.clear()


### PR DESCRIPTION
This PR fixes the failure as follows:
```
/usr/local/lib/python3.7/dist-packages/saichallenger/common/sai_testbed.py:218: in init
    npu.reset()
/usr/local/lib/python3.7/dist-packages/saichallenger/common/sai_npu.py:101: in reset
    self.init(attr)
/usr/local/lib/python3.7/dist-packages/saichallenger/common/sai_npu.py:83: in init
    self.set_sku_mode(self.sku_config)
/usr/local/lib/python3.7/dist-packages/saichallenger/common/sai_npu.py:215: in set_sku_mode
    serdes_oid = data.oid()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <saichallenger.common.sai_data.SaiData object at 0x7fa035ff0c50>, idx = 1

    def oid(self, idx=1):
>       value = self.to_json()[idx]
E       IndexError: list index out of range

/usr/local/lib/python3.7/dist-packages/saichallenger/common/sai_data.py:100: IndexError
```