### PR TITLE
[CI/CD] Fixed checks what Docker images have to be rebuild

### DIFF
--- a/.github/workflows/sc-client-server-deb10.yml
+++ b/.github/workflows/sc-client-server-deb10.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - '.github/workflows/sc-client-server-deb10.yml'
       - 'dockerfiles/buster/Dockerfile.client'
-      - 'dockerfiles/buster/Dockerfile.saithrift-client'
       - 'dockerfiles/buster/Dockerfile.server'
       - 'npu/broadcom/BCM56850/saivs/Dockerfile.server'
       - 'common/**'
@@ -23,11 +22,12 @@ on:
       - 'sai.env'
 
 env:
-  DOCKER_BASE: 'dockerfiles/buster/Dockerfile'
-  DOCKER_REDIS: 'npu/broadcom/BCM56850/saivs/Dockerfile'
-  DOCKER_THRIFT: 'npu/broadcom/BCM56850/saivs/Dockerfile.saithrift'
-  REDIS_RPC: 0
-  THRIFT_RPC: 0
+  DOCKER_CLIENT: 'dockerfiles/buster/Dockerfile.client'
+  DOCKER_SERVER_BASE: 'dockerfiles/buster/Dockerfile.server'
+  DOCKER_SERVER: 'npu/broadcom/BCM56850/saivs/Dockerfile.server'
+  REDIS_CLIENT: 0
+  REDIS_SERVER: 0
+
 
 jobs:
   build-sc-server:
@@ -43,23 +43,25 @@ jobs:
     - name: Check what files were updated
       id: check_changes
       run: |
-        echo 'changed_files=$(git diff --name-only origin/HEAD | xargs)' >> $GITHUB_OUTPUT
+        echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
+        echo "$(git diff --name-only HEAD~1)" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: Check what Docker images have to be rebuild
       run: |
-        for file in "$DOCKER_BASE" "$DOCKER_REDIS" "sai.env"; do
+        for file in "$DOCKER_SERVER_BASE" "$DOCKER_SERVER" "sai.env"; do
           if [[ "${{ steps.check_changes.outputs.changed_files }}" == *"$file"* ]]; then
-            echo "REDIS_RPC=1" >> $GITHUB_ENV
+            echo "REDIS_SERVER=1" >> $GITHUB_ENV
           fi
         done
     
     - name: Build server Docker image
       run: ./build.sh -i server -o deb10
-      if: ${{ env.REDIS_RPC == '1' }}
+      if: ${{ env.REDIS_SERVER == '1' }}
     
     - name: Pull SAI-C server
       run: ./run.sh -i server -o deb10
-      if: ${{ env.REDIS_RPC == '0' }}
+      if: ${{ env.REDIS_SERVER == '0' }}
     
     - name: Save server Docker image
       run: docker save sc-server-trident2-saivs > sc-server.tar
@@ -82,24 +84,25 @@ jobs:
     - name: Check what files were updated
       id: check_changes
       run: |
-        echo 'changed_files=$(git diff --name-only origin/HEAD | xargs)' >> $GITHUB_OUTPUT
+        echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
+        echo "$(git diff --name-only HEAD~1)" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: Check what Docker images have to be rebuild
       run: |
-        changed_files=$(git diff --name-only origin/HEAD | xargs)
-        for file in "$DOCKER_BASE" "$DOCKER_REDIS" "sai.env"; do
-          if [[ "$changed_files" == *"$file"* ]]; then
-            echo "REDIS_RPC=1"
+        for file in "$DOCKER_CLIENT" "sai.env"; do
+          if [[ "${{ steps.check_changes.outputs.changed_files }}" == *"$file"* ]]; then
+            echo "REDIS_CLIENT=1" >> $GITHUB_ENV
           fi
         done
 
     - name: Build client Docker image
       run: ./build.sh -i client -o deb10 --nosnappi
-      if: ${{ env.REDIS_RPC == '1' }}
+      if: ${{ env.REDIS_CLIENT == '1' }}
     
     - name: Pull SAI-C client
       run: ./run.sh -i client -o deb10
-      if: ${{ env.REDIS_RPC == '0' }}
+      if: ${{ env.REDIS_CLIENT == '0' }}
     
     - name: Save client Docker image
       run: docker save sc-client > sc-client.tar
@@ -147,10 +150,10 @@ jobs:
       run: ./run.sh -i server -o deb10
     - name: Update SAI-C server package
       run: ./exec.sh -i server --no-tty pip3 install /sai-challenger/common /sai-challenger
-      if: ${{ env.REDIS_RPC == '0' }}
+      if: ${{ env.REDIS_SERVER == '0' }}
     - name: Update SAI-C client package
       run: ./exec.sh -i client --no-tty pip3 install /sai-challenger/common /sai-challenger
-      if: ${{ env.REDIS_RPC == '0' }}
+      if: ${{ env.REDIS_CLIENT == '0' }}
     - name: Create veth links between client and server dockers
       run: sudo ./veth-create-host.sh sc-server-trident2-saivs-run sc-client-run
 

--- a/.github/workflows/sc-client-server-deb11.yml
+++ b/.github/workflows/sc-client-server-deb11.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - '.github/workflows/sc-client-server-deb11.yml'
       - 'dockerfiles/bullseye/Dockerfile.client'
-      - 'dockerfiles/bullseye/Dockerfile.saithrift-client'
       - 'dockerfiles/bullseye/Dockerfile.server'
       - 'npu/broadcom/BCM56850/saivs/Dockerfile.server'
       - 'common/**'
@@ -23,11 +22,11 @@ on:
       - 'sai.env'
 
 env:
-  DOCKER_BASE: 'dockerfiles/bullseye/Dockerfile'
-  DOCKER_REDIS: 'npu/broadcom/BCM56850/saivs/Dockerfile'
-  DOCKER_THRIFT: 'npu/broadcom/BCM56850/saivs/Dockerfile.saithrift'
-  REDIS_RPC: 0
-  THRIFT_RPC: 0
+  DOCKER_CLIENT: 'dockerfiles/bullseye/Dockerfile.client'
+  DOCKER_SERVER_BASE: 'dockerfiles/bullseye/Dockerfile.server'
+  DOCKER_SERVER: 'npu/broadcom/BCM56850/saivs/Dockerfile.server'
+  REDIS_CLIENT: 0
+  REDIS_SERVER: 0
 
 jobs:
   build-sc-server:
@@ -43,23 +42,25 @@ jobs:
     - name: Check what files were updated
       id: check_changes
       run: |
-        echo 'changed_files=$(git diff --name-only origin/HEAD | xargs)' >> $GITHUB_OUTPUT
+        echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
+        echo "$(git diff --name-only HEAD~1)" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: Check what Docker images have to be rebuild
       run: |
-        for file in "$DOCKER_BASE" "$DOCKER_REDIS" "sai.env"; do
+        for file in "$DOCKER_SERVER_BASE" "$DOCKER_SERVER" "sai.env"; do
           if [[ "${{ steps.check_changes.outputs.changed_files }}" == *"$file"* ]]; then
-            echo "REDIS_RPC=1" >> $GITHUB_ENV
+            echo "REDIS_SERVER=1" >> $GITHUB_ENV
           fi
         done
     
     - name: Build server Docker image
       run: ./build.sh -i server -o deb11
-      if: ${{ env.REDIS_RPC == '1' }}
+      if: ${{ env.REDIS_SERVER == '1' }}
 
     - name: Pull SAI-C server
       run: ./run.sh -i server -o deb11
-      if: ${{ env.REDIS_RPC == '0' }}
+      if: ${{ env.REDIS_SERVER == '0' }}
         
     - name: Save server Docker image
       run: docker save sc-server-trident2-saivs > sc-server.tar
@@ -82,23 +83,25 @@ jobs:
     - name: Check what files were updated
       id: check_changes
       run: |
-        echo 'changed_files=$(git diff --name-only origin/HEAD | xargs)' >> $GITHUB_OUTPUT
+        echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
+        echo "$(git diff --name-only HEAD~1)" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: Check what Docker images have to be rebuild
       run: |
-        for file in "$DOCKER_BASE" "$DOCKER_REDIS" "sai.env"; do
+        for file in "$DOCKER_CLIENT" "sai.env"; do
           if [[ "${{ steps.check_changes.outputs.changed_files }}" == *"$file"* ]]; then
-            echo "REDIS_RPC=1" >> $GITHUB_ENV
+            echo "REDIS_CLIENT=1" >> $GITHUB_ENV
           fi
         done
 
     - name: Build client Docker image
       run: ./build.sh -i client -o deb11 --nosnappi
-      if: ${{ env.REDIS_RPC == '1' }}
+      if: ${{ env.REDIS_CLIENT == '1' }}
     
     - name: Pull SAI-C client
       run: ./run.sh -i client -o deb11
-      if: ${{ env.REDIS_RPC == '0' }}
+      if: ${{ env.REDIS_CLIENT == '0' }}
     
     - name: Save client Docker image
       run: docker save sc-client > sc-client.tar
@@ -146,10 +149,10 @@ jobs:
       run: ./run.sh -i server -o deb11
     - name: Update SAI-C server package
       run: ./exec.sh -i server --no-tty pip3 install /sai-challenger/common /sai-challenger
-      if: ${{ env.REDIS_RPC == '0' }}
+      if: ${{ env.REDIS_SERVER == '0' }}
     - name: Update SAI-C client package
       run: ./exec.sh -i client --no-tty pip3 install /sai-challenger/common /sai-challenger
-      if: ${{ env.REDIS_RPC == '0' }}
+      if: ${{ env.REDIS_CLIENT == '0' }}
     - name: Create veth links between client and server dockers
       run: sudo ./veth-create-host.sh sc-server-trident2-saivs-run sc-client-run
 

--- a/.github/workflows/sc-standalone-deb10.yml
+++ b/.github/workflows/sc-standalone-deb10.yml
@@ -42,7 +42,9 @@ jobs:
     - name: Check what files were updated
       id: check_changes
       run: |
-        echo 'changed_files=$(git diff --name-only origin/HEAD | xargs)' >> $GITHUB_OUTPUT
+        echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
+        echo "$(git diff --name-only HEAD~1)" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: Check what Docker images have to be rebuild
       run: |

--- a/.github/workflows/sc-standalone-deb11.yml
+++ b/.github/workflows/sc-standalone-deb11.yml
@@ -42,7 +42,9 @@ jobs:
     - name: Check what files were updated
       id: check_changes
       run: |
-        echo 'changed_files=$(git diff --name-only origin/HEAD | xargs)' >> $GITHUB_OUTPUT
+        echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
+        echo "$(git diff --name-only HEAD~1)" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: Check what Docker images have to be rebuild
       run: |


### PR DESCRIPTION
This PR fixes the issue introduced by https://github.com/opencomputeproject/SAI-Challenger/pull/182
```
>> Check what Docker images have to be rebuild

Run for file in "$DOCKER_BASE" "$DOCKER_REDIS" "sai.env"; do
  for file in "$DOCKER_BASE" "$DOCKER_REDIS" "sai.env"; do
    if [[ "$(git diff --name-only origin/HEAD | xargs)" == *"$file"* ]]; then
      echo "REDIS_RPC=1" >> $GITHUB_ENV
    fi
  done
  for file in "$DOCKER_BASE" "$DOCKER_THRIFT" "sai.env"; do
    if [[ "$(git diff --name-only origin/HEAD | xargs)" == *"$file"* ]]; then
      echo "THRIFT_RPC=1" >> $GITHUB_ENV
    fi
  done
  shell: /usr/bin/bash -e {0}
  env:
    DOCKER_BASE: dockerfiles/buster/Dockerfile
    DOCKER_REDIS: npu/broadcom/BCM[5](https://github.com/opencomputeproject/SAI-Challenger/actions/runs/6361337156/job/17275686244?pr=205#step:5:5)[6](https://github.com/opencomputeproject/SAI-Challenger/actions/runs/6361337156/job/17275686244?pr=205#step:5:6)[8](https://github.com/opencomputeproject/SAI-Challenger/actions/runs/6361337156/job/17275686244?pr=205#step:5:8)50/saivs/Dockerfile
    DOCKER_THRIFT: npu/broadcom/BCM56850/saivs/Dockerfile.saithrift
    REDIS_RPC: 0
    THRIFT_RPC: 0
fatal: ambiguous argument 'origin/HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: ambiguous argument 'origin/HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
  . . . . . .
```