### PR TITLE
Fixed pytest warnings

### DIFF
--- a/common/sai_dut.py
+++ b/common/sai_dut.py
@@ -137,7 +137,7 @@ class SaiDutSonic(SaiDut):
 
         # Write to CONFIG_DB SONiC device information needed on syncd start
         config_db = redis.Redis(host=self.server_ip, port=self.port, db=4)
-        config_db.hmset("DEVICE_METADATA|localhost", device_metadata)
+        config_db.hset("DEVICE_METADATA|localhost", mapping=device_metadata)
         config_db.set("CONFIG_DB_INITIALIZED", "1")
 
     def deinit(self):

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    dpu: mark DPU specific tests


### PR DESCRIPTION
Fixed pytest warnings as follows:
```
api/test_dash_acl_group.py:12
  /sai-challenger/tests/api/test_dash_acl_group.py:12: PytestUnknownMarkWarning: Unknown pytest.mark.dpu - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.dpu
```
```
test_l2_basic.py::test_l2_trunk_to_trunk_vlan
  /usr/local/lib/python3.9/dist-packages/saichallenger/common/sai_dut.py:140: DeprecationWarning: Redis.hmset() is deprecated. Use Redis.hset() instead.
    config_db.hmset("DEVICE_METADATA|localhost", device_metadata)
```