### PR TITLE
Fixed libyang-dev dependency for Deb10

### DIFF
--- a/dockerfiles/buster/Dockerfile
+++ b/dockerfiles/buster/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get install -y \
         make libtool m4 autoconf dh-exec debhelper automake cmake pkg-config \
         libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev swig3.0 \
         libgtest-dev libgmock-dev libboost-dev autoconf-archive \
-        uuid-dev libboost-serialization-dev libyang-dev libyang0.16
+        uuid-dev libboost-serialization-dev libyang-dev libyang1
 
 RUN apt-get install -y \
         libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev libzmq3-dev

--- a/dockerfiles/buster/Dockerfile.server
+++ b/dockerfiles/buster/Dockerfile.server
@@ -40,7 +40,7 @@ RUN apt-get install -y \
         make libtool m4 autoconf dh-exec debhelper automake cmake pkg-config \
         libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev swig3.0 \
         libgtest-dev libgmock-dev libboost-dev autoconf-archive \
-        uuid-dev libboost-serialization-dev libyang-dev libyang0.16 \
+        uuid-dev libboost-serialization-dev libyang-dev libyang1 \
         nlohmann-json3-dev
 
 RUN apt-get install -y \


### PR DESCRIPTION
This PR fixes dependency issue:
```
#11 1.394 The following packages have unmet dependencies:
#11 1.457  libyang-dev : Depends: libyang1 (= 1.0.225-1.1~deb10u1) but it is not going to be installed
ERROR: "docker build -f dockerfiles/${BASE_OS}/Dockerfile.server -t sc-server-base:${BASE_OS} ." command filed with exit code 1.
```