### PR TITLE
Fixed flush_fdb_entries() for Thrift RPC

### DIFF
--- a/common/sai_client/sai_thrift_client/sai_thrift_client.py
+++ b/common/sai_client/sai_thrift_client/sai_thrift_client.py
@@ -235,7 +235,7 @@ class SaiThriftClient(SaiClient):
 
     def flush_fdb_entries(self, obj, attrs=None):
         obj_type, _, _ = self.obj_to_items(obj)
-        attr_kwargs = dict(ThriftConverter.convert_attributes_to_thrift(attrs))
+        attr_kwargs = dict(ThriftConverter.convert_attributes_to_thrift(attrs)) if attrs else {}
         result = sai_adapter.sai_thrift_flush_fdb_entries(self.thrift_client, **attr_kwargs)
 
     def bulk_create(self, obj_type, keys, attrs, obj_count=0, do_assert=True):


### PR DESCRIPTION
Fixed flush_fdb_entries() for Thrift RPC in case no attributes specified