### PR TITLE
Initial version of Debian Bookworm Dockers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,8 @@ base_os_map["deb10"]="buster"
 base_os_map["buster"]="buster"
 base_os_map["deb11"]="bullseye"
 base_os_map["bullseye"]="bullseye"
+base_os_map["deb12"]="bookworm"
+base_os_map["bookworm"]="bookworm"
 
 
 print-help() {
@@ -36,7 +38,7 @@ print-help() {
     echo "     Target device with this NPU"
     echo "  -s [redis|thrift]"
     echo "     SAI interface"
-    echo "  -o [buster|bullseye]"
+    echo "  -o [buster|bullseye|bookworm]"
     echo "     Docker image base OS"
     echo "  --nosnappi"
     echo "     Do not include snappi to the final image"
@@ -142,6 +144,14 @@ print-build-options() {
 }
 
 trap print-build-options EXIT
+
+# Link the pip configuration file to copy to the Docker image
+if [ "${BASE_OS}" = "bookworm" ]; then
+    rm -f pip.conf
+    if [ -f dockerfiles/${BASE_OS}/pip.conf ]; then
+        ln -s dockerfiles/${BASE_OS}/pip.conf pip.conf
+    fi
+fi
 
 # Build base Docker image
 if [ "${IMAGE_TYPE}" = "standalone" ]; then

--- a/build.sh
+++ b/build.sh
@@ -145,14 +145,6 @@ print-build-options() {
 
 trap print-build-options EXIT
 
-# Link the pip configuration file to copy to the Docker image
-if [ "${BASE_OS}" = "bookworm" ]; then
-    rm -f pip.conf
-    if [ -f dockerfiles/${BASE_OS}/pip.conf ]; then
-        ln -s dockerfiles/${BASE_OS}/pip.conf pip.conf
-    fi
-fi
-
 # Build base Docker image
 if [ "${IMAGE_TYPE}" = "standalone" ]; then
     docker build -f dockerfiles/${BASE_OS}/Dockerfile -t sc-base:${BASE_OS} .

--- a/dockerfiles/bookworm/Dockerfile
+++ b/dockerfiles/bookworm/Dockerfile
@@ -3,8 +3,10 @@ FROM debian:bookworm-slim
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Copy the pip.conf file
-COPY pip.conf /root/.config/pip/pip.conf
+# Generate the pip configuration file
+RUN mkdir -p /root/.config/pip \
+        && echo "[global]" > /root/.config/pip/pip.conf \
+        && echo "break-system-packages = true" >> /root/.config/pip/pip.conf
 
 # Install generic packages
 RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \

--- a/dockerfiles/bookworm/Dockerfile
+++ b/dockerfiles/bookworm/Dockerfile
@@ -1,0 +1,133 @@
+FROM debian:bookworm-slim
+
+## Make apt-get non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Copy the pip.conf file
+COPY pip.conf /root/.config/pip/pip.conf
+
+# Install generic packages
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \
+        apt-utils \
+        vim \
+        curl \
+        wget \
+        iproute2 \
+        unzip \
+        git \
+        procps \
+        build-essential \
+        graphviz \
+        doxygen \
+        aspell \
+        python3-pip \
+        rsyslog \
+        supervisor
+
+# Add support for supervisord to handle startup dependencies
+RUN pip3 install supervisord-dependent-startup==1.4.0
+
+# Install dependencies
+RUN apt-get install -y redis-server libhiredis0.14 python3-redis libc-ares2
+
+# Install sonic-swss-common & sonic-sairedis building dependencies
+RUN apt-get install -y \
+        make libtool m4 autoconf dh-exec debhelper automake cmake pkg-config \
+        libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev swig \
+        libgtest-dev libgmock-dev libboost-dev autoconf-archive \
+        uuid-dev libboost-serialization-dev nlohmann-json3-dev
+
+RUN apt-get install -y \
+        libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev libzmq3-dev
+
+COPY sai.env /
+
+RUN git clone --recursive https://github.com/sonic-net/sonic-swss-common \
+        && cd sonic-swss-common \
+        && . /sai.env \
+        && git checkout ${SWSS_COMMON_ID} \
+        && ./autogen.sh \
+        && export DEB_BUILD_PROFILES="nopython2 noyangmod" \
+        && export DEB_DH_SHLIBDEPS_ARGS_ALL=--dpkg-shlibdeps-params=--ignore-missing-info \
+        && dpkg-buildpackage -us -uc -b --jobs=auto \
+        && cd .. \
+        && dpkg -i libswsscommon_1.0.0_amd64.deb \
+        && dpkg -i libswsscommon-dev_1.0.0_amd64.deb \
+        && rm -rf sonic-swss-common \
+        && rm -f *swsscommon*
+
+WORKDIR /sai
+
+# Install ptf_nn_agent dependencies
+RUN apt-get install -y libffi-dev \
+        && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+        && tar xvfz 1.0.0.tar.gz \
+        && cd nanomsg-1.0.0 \
+        && mkdir -p build \
+        && cd build \
+        && cmake .. \
+        && make install \
+        && ldconfig \
+        && cd ../.. \
+        && rm -rf 1.0.0.tar.gz nanomsg-1.0.0 \
+        && pip3 install nnpy
+
+# Update Redis configuration:
+# - Enable keyspace notifications as per sonic-swss-common/README.md
+# - Do not daemonize redis-server since supervisord will manage it
+# - Do not save Redis DB on disk
+RUN sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf \
+        && sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf \
+        && sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf \
+        && sed -ri 's/notify-keyspace-events ""/notify-keyspace-events AKE/' /etc/redis/redis.conf \
+        && sed -ri 's/^daemonize yes/daemonize no/' /etc/redis/redis.conf \
+        && sed -ri 's/^save/# save/' /etc/redis/redis.conf
+
+# Disable kernel logging support
+RUN sed -ri '/imklog/s/^/#/' /etc/rsyslog.conf
+
+# Install PTF dependencies
+RUN pip3 install scapy dpkt
+
+# Install ptf_nn_agent and PTF helpers (required by sai_dataplane.py)
+COPY ptf/ptf_nn/ptf_nn_agent.py      /ptf/ptf_nn/ptf_nn_agent.py
+COPY ptf/setup.py                    /ptf/setup.py
+COPY ptf/README.md                   /ptf/README.md
+COPY ptf/src/ptf/*.py                /ptf/src/ptf/
+COPY ptf/src/ptf/platforms/*.py      /ptf/src/ptf/platforms/
+COPY ptf/requirements.txt            /ptf/requirements.txt
+
+RUN echo "#mock" > /ptf/ptf && pip3 install /ptf
+
+# Install SAI attributes metadata JSON generator
+COPY scripts/gen_attr_list /sai/gen_attr_list
+
+# Install SAI-C dependencies
+RUN pip3 install pytest pytest_dependency pytest-html aenum pdbpp macaddress click==8.0
+RUN apt-get install -y python3-paramiko
+
+# Fix invoke/loader.py:3: DeprecationWarning caused by load_module()
+RUN pip3 install --upgrade invoke>=2.2.0
+
+# Deploy SAI Challenger
+COPY common              /sai-challenger/common
+COPY cli                 /sai-challenger/cli
+COPY topologies          /sai-challenger/topologies
+COPY setup.py            /sai-challenger/setup.py
+COPY scripts/sai-cli-completion.sh   /sai-challenger/scripts/sai-cli-completion.sh
+RUN echo ". /sai-challenger/scripts/sai-cli-completion.sh" >> /root/.bashrc
+
+# Deploy a remote commands listener
+COPY scripts/redis-cmd-listener.py   /sai-challenger/scripts/redis-cmd-listener.py
+
+# Install SAI Challenger
+RUN pip3 install /sai-challenger/common /sai-challenger
+
+WORKDIR /sai-challenger/tests
+
+# Setup supervisord
+COPY scripts/veth-create.sh    /usr/bin/veth-create.sh
+COPY scripts/redis_start.sh    /usr/bin/redis_start.sh
+COPY configs/supervisord.conf  /etc/supervisor/conf.d/supervisord.conf
+
+CMD ["/usr/bin/supervisord"]

--- a/dockerfiles/bookworm/Dockerfile.client
+++ b/dockerfiles/bookworm/Dockerfile.client
@@ -1,0 +1,121 @@
+FROM debian:bookworm-slim
+
+## Make apt-get non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Copy the pip.conf file
+COPY pip.conf /root/.config/pip/pip.conf
+
+# Install generic packages
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \
+        apt-utils \
+        build-essential \
+        python3 \
+        python3-pip \
+        python3-redis \
+        iproute2 \
+        rsyslog \
+        supervisor \
+        cmake \
+        graphviz \
+        doxygen \
+        aspell \
+        git \
+        wget \
+        libffi-dev \
+        nlohmann-json3-dev \
+        python3-paramiko \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /sai
+
+# Install SAI attributes metadata JSON generator
+COPY scripts/gen_attr_list /sai/gen_attr_list
+COPY sai.env /
+
+RUN git clone https://github.com/opencomputeproject/SAI.git \
+        && cd SAI \
+        && . /sai.env \
+        && git checkout ${SAI_ID} \
+        && cd meta \
+        && make saimetadata.h \
+        && make saimetadata.c \
+        && cd .. \
+        && mkdir /usr/include/sai \
+        && cp inc/* /usr/include/sai/ \
+        && cp experimental/* /usr/include/sai/ \
+        && cp meta/sai*.h /usr/include/sai/ \
+        && cp meta/saimetadatautils.c /sai/gen_attr_list/ \
+        && cp meta/saimetadata.c /sai/gen_attr_list/ \
+        && cp meta/saiserialize.c /sai/gen_attr_list/ \
+        && cd /sai/gen_attr_list \
+        && mkdir build && cd build \
+        && cmake .. \
+        && make -j$(nproc) \
+        && mkdir -p /etc/sai \
+        && ./attr_list_generator > /etc/sai/sai.json.tmp \
+        && python3 -mjson.tool /etc/sai/sai.json.tmp > /etc/sai/sai.json \
+        && rm /etc/sai/sai.json.tmp \
+        && rm -rf /sai/SAI
+
+# Install SAI-C dependencies
+RUN pip3 install pytest pytest_dependency pytest-html aenum pdbpp macaddress click==8.0
+
+ARG NOSNAPPI
+RUN if [ "$NOSNAPPI" != "y" ]; then \
+        pip3 install snappi==0.11.14 snappi_ixnetwork==0.9.1 ; \
+    fi
+
+# Fix invoke/loader.py:3: DeprecationWarning caused by load_module()
+RUN pip3 install --upgrade invoke>=2.2.0
+
+# Install PTF dependencies
+RUN pip3 install scapy dpkt
+
+# Install ptf_nn_agent dependencies
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+        && tar xvfz 1.0.0.tar.gz \
+        && cd nanomsg-1.0.0 \
+        && mkdir -p build \
+        && cd build \
+        && cmake .. \
+        && make install \
+        && ldconfig \
+        && cd ../.. \
+        && rm -rf 1.0.0.tar.gz nanomsg-1.0.0 \
+        && pip3 install nnpy
+
+# Install ptf_nn_agent and PTF helpers (required by sai_dataplane.py)
+COPY ptf/ptf_nn/ptf_nn_agent.py      /ptf/ptf_nn/ptf_nn_agent.py
+COPY ptf/setup.py                    /ptf/setup.py
+COPY ptf/README.md                   /ptf/README.md
+COPY ptf/src/ptf/*.py                /ptf/src/ptf/
+COPY ptf/src/ptf/platforms/*.py      /ptf/src/ptf/platforms/
+COPY ptf/requirements.txt            /ptf/requirements.txt
+RUN echo "#mock" > /ptf/ptf && pip3 install /ptf
+
+# Deploy SAI Challenger
+COPY common              /sai-challenger/common
+COPY cli                 /sai-challenger/cli
+COPY topologies          /sai-challenger/topologies
+COPY setup.py            /sai-challenger/setup.py
+COPY scripts/sai-cli-completion.sh   /sai-challenger/scripts/sai-cli-completion.sh
+RUN echo ". /sai-challenger/scripts/sai-cli-completion.sh" >> /root/.bashrc
+
+# Deploy a remote commands listener (mock for setup.py)
+RUN mkdir -p /sai-challenger/scripts \
+        && echo "#mock" > /sai-challenger/scripts/redis-cmd-listener.py
+
+# Install SAI Challenger
+RUN pip3 install /sai-challenger/common /sai-challenger
+
+# Disable kernel logging support
+RUN sed -ri '/imklog/s/^/#/' /etc/rsyslog.conf
+
+WORKDIR /sai-challenger/tests
+
+# Setup supervisord
+COPY configs/client/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+CMD ["/usr/bin/supervisord"]
+

--- a/dockerfiles/bookworm/Dockerfile.client
+++ b/dockerfiles/bookworm/Dockerfile.client
@@ -3,8 +3,10 @@ FROM debian:bookworm-slim
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Copy the pip.conf file
-COPY pip.conf /root/.config/pip/pip.conf
+# Generate the pip configuration file
+RUN mkdir -p /root/.config/pip \
+        && echo "[global]" > /root/.config/pip/pip.conf \
+        && echo "break-system-packages = true" >> /root/.config/pip/pip.conf
 
 # Install generic packages
 RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \

--- a/dockerfiles/bookworm/Dockerfile.saithrift-client
+++ b/dockerfiles/bookworm/Dockerfile.saithrift-client
@@ -1,7 +1,9 @@
 FROM sc-client:bookworm
 
-# Copy the pip.conf file
-COPY pip.conf /root/.config/pip/pip.conf
+# Generate the pip configuration file
+RUN mkdir -p /root/.config/pip \
+        && echo "[global]" > /root/.config/pip/pip.conf \
+        && echo "break-system-packages = true" >> /root/.config/pip/pip.conf
 
 ENV SAIGEN_DEPS    libgetopt-long-descriptive-perl libconst-fast-perl \
                    libtemplate-perl libnamespace-autoclean-perl \

--- a/dockerfiles/bookworm/Dockerfile.saithrift-client
+++ b/dockerfiles/bookworm/Dockerfile.saithrift-client
@@ -1,0 +1,57 @@
+FROM sc-client:bookworm
+
+# Copy the pip.conf file
+COPY pip.conf /root/.config/pip/pip.conf
+
+ENV SAIGEN_DEPS    libgetopt-long-descriptive-perl libconst-fast-perl \
+                   libtemplate-perl libnamespace-autoclean-perl \
+                   libmoose-perl libmoosex-aliases-perl
+
+WORKDIR /sai
+
+# Install Thrift code gen
+RUN apt-get -o Acquire::Check-Valid-Until=false update \
+        && apt install -y libtool pkg-config \
+        && wget "http://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz" \
+        && tar -xf thrift-0.11.0.tar.gz \
+        && cd thrift-0.11.0 \
+        && ./bootstrap.sh \
+        && ./configure --prefix=/usr --with-cpp --with-python \
+            --with-qt4=no --with-qt5=no --with-csharp=no --with-java=no --with-erlang=no \
+            --with-nodejs=no --with-lua=no --with-per=no --with-php=no --with-dart=no \
+            --with-ruby=no --with-haskell=no --with-go=no --with-rs=no --with-haxe=no \
+            --with-dotnetcore=no --with-d=no \
+        && make && make install \
+        && pip3 install ctypesgen lib/py \
+        && cd /sai \
+        && rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz \
+        && rm -rf /var/lib/apt/lists/*
+
+COPY sai.env /sai
+
+RUN apt-get -o Acquire::Check-Valid-Until=false update \
+        && apt install -y ${SAIGEN_DEPS} \
+        && git clone https://github.com/opencomputeproject/SAI.git \
+        && cd SAI \
+        && . /sai/sai.env \
+        && git checkout ${SAI_ID} \
+        && cp inc/* /usr/include/sai/ \
+        && cp experimental/* /usr/include/sai/ \
+        && cd test/saithriftv2/ \
+        && make meta \
+        && make install-pylib \
+        && cd dist \
+        && tar zxf saithrift-0.9.tar.gz \
+        && cd saithrift-0.9 \
+        && python3 setup.py install \
+        && cd /sai \
+        && rm -rf SAI \
+        && apt purge -y ${SAIGEN_DEPS} \
+        && rm -rf /var/lib/apt/lists/*
+
+# Install PTF dependencies
+RUN pip3 install pysubnettree
+
+WORKDIR /sai-challenger/tests
+
+CMD ["/usr/bin/supervisord"]

--- a/dockerfiles/bookworm/Dockerfile.saithrift-server
+++ b/dockerfiles/bookworm/Dockerfile.saithrift-server
@@ -3,8 +3,10 @@ FROM debian:bookworm-slim
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Copy the pip.conf file
-COPY pip.conf /root/.config/pip/pip.conf
+# Generate the pip configuration file
+RUN mkdir -p /root/.config/pip \
+        && echo "[global]" > /root/.config/pip/pip.conf \
+        && echo "break-system-packages = true" >> /root/.config/pip/pip.conf
 
 COPY sai.env /
 

--- a/dockerfiles/bookworm/Dockerfile.saithrift-server
+++ b/dockerfiles/bookworm/Dockerfile.saithrift-server
@@ -1,0 +1,82 @@
+FROM debian:bookworm-slim
+
+## Make apt-get non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Copy the pip.conf file
+COPY pip.conf /root/.config/pip/pip.conf
+
+COPY sai.env /
+
+# Install generic packages
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \
+        apt-utils \
+        vim \
+        curl \
+        wget \
+        iproute2 \
+        unzip \
+        git \
+        procps \
+        build-essential \
+        graphviz \
+        doxygen \
+        aspell \
+        python3-pip \
+        rsyslog \
+        supervisor
+
+# Add support for supervisord to handle startup dependencies
+RUN pip3 install supervisord-dependent-startup==1.4.0
+
+# Install generic packages
+RUN apt-get install -y \
+        libtemplate-perl \
+        libconst-fast-perl \
+        libmoosex-aliases-perl \
+        libnamespace-autoclean-perl \
+        libgetopt-long-descriptive-perl \
+        aspell-en bison flex g++ \
+        libboost-all-dev libevent-dev libssl-dev \
+        libpython3-dev libpcap-dev
+
+WORKDIR /sai
+
+RUN apt-get install -y pkg-config \
+    && wget "http://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz" \
+    && tar -xf thrift-0.11.0.tar.gz \
+    && cd thrift-0.11.0 \
+    && ./bootstrap.sh \
+    && ./configure --prefix=/usr --with-cpp --with-python \
+        --with-qt4=no --with-qt5=no --with-csharp=no --with-java=no --with-erlang=no \
+        --with-nodejs=no --with-lua=no --with-per=no --with-php=no --with-dart=no \
+        --with-ruby=no --with-haskell=no --with-go=no --with-rs=no --with-haxe=no \
+        --with-dotnetcore=no --with-d=no \
+    && make && make install \
+    && pip3 install ctypesgen lib/py \
+    && cd /sai \
+    && rm -rf thrift-0.11.0 thrift-0.11.0.tar.gz ;
+
+ENV SAITHRIFTV2=y
+ENV GEN_SAIRPC_OPTS="-cve"
+ENV SAIRPC_EXTRA_LIBS="-L/usr/local/lib/ -lpthread"
+
+RUN git clone https://github.com/opencomputeproject/SAI.git \
+    && cd SAI && git fetch origin \
+    && . /sai.env \
+    && git checkout ${SAI_ID} \
+    && cd meta \
+    && make all libsaimetadata.so libsai.so \
+    && cp libsaimetadata.so /usr/lib \
+    && cp libsai.so /usr/lib \
+    && cd .. \
+    && mkdir /usr/include/sai/ \
+    && cp ./inc/sai*.h /usr/include/sai/ \
+    && cp ./experimental/sai*.h /usr/include/sai/ \
+    && make saithrift-install
+
+WORKDIR /sai-challenger
+
+COPY configs/server/supervisord.conf.thrift /etc/supervisor/conf.d/supervisord.conf
+
+CMD ["/usr/bin/supervisord"]

--- a/dockerfiles/bookworm/Dockerfile.server
+++ b/dockerfiles/bookworm/Dockerfile.server
@@ -3,8 +3,10 @@ FROM debian:bookworm-slim
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Copy the pip.conf file
-COPY pip.conf /root/.config/pip/pip.conf
+# Generate the pip configuration file
+RUN mkdir -p /root/.config/pip \
+        && echo "[global]" > /root/.config/pip/pip.conf \
+        && echo "break-system-packages = true" >> /root/.config/pip/pip.conf
 
 # Install generic packages
 RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \

--- a/dockerfiles/bookworm/Dockerfile.server
+++ b/dockerfiles/bookworm/Dockerfile.server
@@ -1,0 +1,120 @@
+FROM debian:bookworm-slim
+
+## Make apt-get non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Copy the pip.conf file
+COPY pip.conf /root/.config/pip/pip.conf
+
+# Install generic packages
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \
+        apt-utils \
+        vim \
+        curl \
+        wget \
+        iproute2 \
+        unzip \
+        git \
+        procps \
+        build-essential \
+        graphviz \
+        doxygen \
+        aspell \
+        python3-pip \
+        rsyslog \
+        supervisor
+
+# Add support for supervisord to handle startup dependencies
+RUN pip3 install supervisord-dependent-startup==1.4.0
+
+# Install dependencies
+RUN apt-get install -y redis-server libhiredis0.14 python3-redis libc-ares2
+
+# Install sonic-swss-common & sonic-sairedis building dependencies
+RUN apt-get install -y \
+        make libtool m4 autoconf dh-exec debhelper automake cmake pkg-config \
+        libhiredis-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev swig \
+        libgtest-dev libgmock-dev libboost-dev autoconf-archive \
+        uuid-dev libboost-serialization-dev nlohmann-json3-dev
+
+RUN apt-get install -y \
+        libnl-3-dev libnl-genl-3-dev libnl-route-3-dev libnl-nf-3-dev libzmq3-dev
+
+COPY sai.env /
+RUN git clone --recursive https://github.com/sonic-net/sonic-swss-common \
+        && cd sonic-swss-common \
+        && . /sai.env \
+        && git checkout ${SWSS_COMMON_ID} \
+        && ./autogen.sh \
+        && export DEB_BUILD_PROFILES="nopython2 noyangmod" \
+        && dpkg-buildpackage -us -uc -b --jobs=auto \
+        && cd .. \
+        && dpkg -i libswsscommon_1.0.0_amd64.deb \
+        && dpkg -i libswsscommon-dev_1.0.0_amd64.deb \
+        && rm -rf sonic-swss-common \
+        && rm -f *swsscommon*
+
+WORKDIR /sai
+
+# Install ptf_nn_agent dependencies
+RUN apt-get install -y libffi-dev \
+        && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+        && tar xvfz 1.0.0.tar.gz \
+        && cd nanomsg-1.0.0 \
+        && mkdir -p build \
+        && cd build \
+        && cmake .. \
+        && make install \
+        && ldconfig \
+        && cd ../.. \
+        && rm -rf 1.0.0.tar.gz nanomsg-1.0.0 \
+        && pip3 install nnpy
+
+# Update Redis configuration:
+# - Enable keyspace notifications as per sonic-swss-common/README.md
+# - Do not daemonize redis-server since supervisord will manage it
+# - Do not save Redis DB on disk
+RUN sed -ri 's/^# unixsocket/unixsocket/' /etc/redis/redis.conf \
+        && sed -ri 's/^unixsocketperm .../unixsocketperm 777/' /etc/redis/redis.conf \
+        && sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf \
+        && sed -ri 's/notify-keyspace-events ""/notify-keyspace-events AKE/' /etc/redis/redis.conf \
+        && sed -ri 's/^daemonize yes/daemonize no/' /etc/redis/redis.conf \
+        && sed -ri 's/^save/# save/' /etc/redis/redis.conf
+
+# Disable kernel logging support
+RUN sed -ri '/imklog/s/^/#/' /etc/rsyslog.conf
+
+# Install ptf_nn_agent and PTF helpers (required by sai_dataplane.py)
+COPY ptf/ptf_nn/ptf_nn_agent.py      /ptf/ptf_nn/ptf_nn_agent.py
+COPY ptf/setup.py                    /ptf/setup.py
+COPY ptf/README.md                   /ptf/README.md
+COPY ptf/src/ptf/*.py                /ptf/src/ptf/
+COPY ptf/src/ptf/platforms/*.py      /ptf/src/ptf/platforms/
+COPY ptf/requirements.txt            /ptf/requirements.txt
+
+RUN echo "#mock" > /ptf/ptf && pip3 install /ptf
+
+# Install SAI Challenger CLI dependencies
+RUN pip3 install click==8.0 pytest
+
+# Deploy SAI Challenger CLI
+COPY setup.py            /sai-challenger/setup.py
+COPY cli/__init__.py     /sai-challenger/cli/__init__.py
+COPY common              /sai-challenger/common
+COPY topologies          /sai-challenger/topologies
+COPY .build/*            /sai-challenger/
+
+# Deploy a remote commands listener
+COPY scripts/redis-cmd-listener.py   /sai-challenger/scripts/redis-cmd-listener.py
+
+# Install SAI Challenger
+RUN pip3 install /sai-challenger/common /sai-challenger
+
+WORKDIR /sai-challenger
+
+# Setup supervisord
+COPY scripts/wait-interfaces.sh /usr/bin/wait-interfaces.sh
+COPY scripts/redis_start.sh    /usr/bin/redis_start.sh
+COPY configs/server/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+CMD ["/usr/bin/supervisord"]

--- a/dockerfiles/bookworm/pip.conf
+++ b/dockerfiles/bookworm/pip.conf
@@ -1,0 +1,2 @@
+[global]
+break-system-packages = true

--- a/dockerfiles/bookworm/pip.conf
+++ b/dockerfiles/bookworm/pip.conf
@@ -1,2 +1,0 @@
-[global]
-break-system-packages = true

--- a/run.sh
+++ b/run.sh
@@ -22,6 +22,8 @@ base_os_map["deb10"]="buster"
 base_os_map["buster"]="buster"
 base_os_map["deb11"]="bullseye"
 base_os_map["bullseye"]="bullseye"
+base_os_map["deb12"]="bookworm"
+base_os_map["bookworm"]="bookworm"
 
 
 print-help() {
@@ -42,7 +44,7 @@ print-help() {
     echo "  -r Remove Docker after run"
     echo "  -s [redis|thrift]"
     echo "     SAI interface"
-    echo "  -o [buster|bullseye]"
+    echo "  -o [buster|bullseye|bookworm]"
     echo "     Docker image base OS"
     echo
     exit 0


### PR DESCRIPTION
#### Build and run SAI Challenger in standalone mode:

```
$ ./build.sh -a trident2 -t saivs -o bookworm --nosnappi
...
===========================================
     SAI Challenger build options
===========================================

 Docker image type  : standalone
 Base OS            : bookworm
 ASIC name          : trident2
 ASIC target        : saivs
 Platform path      : ./npu/broadcom/trident2
 SAI interface      : redis

===========================================

$ ./run.sh -a trident2 -t saivs -o bookworm
3ecfb925a97c13355a11ae4f1ae5f70beb747e5985cd1b7bf3c6d068993afe5e

===========================================
     SAI Challenger start options
===========================================

 Docker image type  : standalone
 Base OS            : bookworm
 ASIC name          : trident2
 ASIC target        : saivs
 Platform path      : ./npu/broadcom/trident2
 SAI interface      : redis

===========================================

$ ./exec.sh -t saivs pytest --testbed=saivs_standalone -v -k "test_l2_basic"
...
=================================================================== 13 passed, 1360 deselected, 3 warnings in 22.69s ===================================================================

===========================================
     SAI Challenger run options
===========================================

 Docker image type  : standalone
 ASIC name          : trident2
 ASIC target        : saivs
 Platform path      : ./npu/broadcom/trident2
 SAI interface      : redis
 Container name     : sc-trident2-saivs-run
 Command            : pytest --testbed=saivs_standalone -v -k test_l2_basic

===========================================
$ docker ps -a
CONTAINER ID   IMAGE                        COMMAND                  CREATED              STATUS              PORTS     NAMES
3ecfb925a97c   sc-trident2-saivs:bookworm   "/usr/bin/supervisord"   About a minute ago   Up About a minute             sc-trident2-saivs-run
$ docker images
REPOSITORY          TAG        IMAGE ID       CREATED         SIZE
sc-trident2-saivs   bookworm   3476fe4c84ba   2 minutes ago   1.58GB
sc-base             bookworm   bdc4b00b41fe   6 minutes ago   1.34GB

```

#### Build and run SAI Challenger in client-server mode:

```
$ ./build.sh -i client -s thrift -o bookworm --nosnappi
...
===========================================
     SAI Challenger build options
===========================================

 Docker image type  : client
 Base OS            : bookworm
 ASIC name          : 
 ASIC target        : 
 Platform path      : 
 SAI interface      : thrift

===========================================

$ ./build.sh -i server -s thrift -a trident2 -t saivs -o bookworm --nosnappi
...
===========================================
     SAI Challenger build options
===========================================

 Docker image type  : server
 Base OS            : bookworm
 ASIC name          : trident2
 ASIC target        : saivs
 Platform path      : ./npu/broadcom/trident2
 SAI interface      : thrift

===========================================

$ ./run.sh -i client -s thrift -o bookworm
3c45acea4845e761008aa7ada48a03257e97105527c62c45cbdeaf4fd6fcca73

===========================================
     SAI Challenger start options
===========================================

 Docker image type  : client
 Base OS            : bookworm
 ASIC name          : 
 ASIC target        : 
 Platform path      : 
 SAI interface      : thrift

===========================================

$ ./run.sh -i server -s thrift -a trident2 -t saivs -o bookworm
c946f8c7e241c0301748d1889173b615ec110454cbb2d44949df78e7f8d29752

===========================================
     SAI Challenger start options
===========================================

 Docker image type  : server
 Base OS            : bookworm
 ASIC name          : trident2
 ASIC target        : saivs
 Platform path      : ./npu/broadcom/trident2
 SAI interface      : thrift

===========================================

$ ./exec.sh -i client -s thrift pytest --testbed=saivs_client_server -v -k "test_l2_basic"
=============================================================================== short test summary info ================================================================================
ERROR test_l2_basic.py::test_l2_access_to_access_vlan - AssertionError: Redis server has not started yet...                      
ERROR test_l2_basic.py::test_l2_trunk_to_trunk_vlan - AssertionError: Redis server has not started yet...                  
ERROR test_l2_basic.py::test_l2_access_to_trunk_vlan - AssertionError: Redis server has not started yet...    
ERROR test_l2_basic.py::test_l2_trunk_to_access_vlan - AssertionError: Redis server has not started yet...                                    
ERROR test_l2_basic.py::test_l2_flood - AssertionError: Redis server has not started yet...                                                                                             
ERROR test_l2_basic.py::test_l2_lag - AssertionError: Redis server has not started yet...
ERROR test_l2_basic.py::test_l2_lag_hash_seed - AssertionError: Redis server has not started yet...
ERROR test_l2_basic.py::test_l2_vlan_bcast_ucast - AssertionError: Redis server has not started yet...
ERROR test_l2_basic.py::test_l2_mtu - AssertionError: Redis server has not started yet...
ERROR test_l2_basic.py::test_fdb_bulk_create - AssertionError: Redis server has not started yet...
ERROR test_l2_basic.py::test_fdb_bulk_remove - AssertionError: Redis server has not started yet...
ERROR test_l2_basic.py::test_l2_mac_move_1 - AssertionError: Redis server has not started yet...
ERROR test_l2_basic_dd.py::test_l2_trunk_to_trunk_vlan_dd - AssertionError: Redis server has not started yet...
=================================================================== 1360 deselected, 2 warnings, 13 errors in 10.52s ===================================================================
ERROR: "docker exec ${TTY} ${CONTAINER} bash -c "${EXEC_CMD}"" command filed with exit code 1.

===========================================
     SAI Challenger run options
===========================================

 Docker image type  : client
 Container name     : sc-thrift-client-run
 Command            : pytest --testbed=saivs_client_server -v -k test_l2_basic

===========================================
...
root@c946f8c7e241:/# tail /var/log/syslog 
2024-11-28T15:09:04.483992+00:00 c946f8c7e241 supervisord: saiserver insert: SAI_VS_INTERFACE_LANE_MAP_FILE:/usr/share/sonic/hwsku/lanemap.ini
2024-11-28T15:09:04.483994+00:00 c946f8c7e241 supervisord: saiserver Failed to initialize SAI api: -15
2024-11-28T15:09:07.510412+00:00 c946f8c7e241 supervisord: saiserver port map file: /usr/share/sonic/hwsku/port_config.ini
2024-11-28T15:09:07.510418+00:00 c946f8c7e241 supervisord: saiserver profile map file: /usr/share/sonic/hwsku/sai.profile
2024-11-28T15:09:07.510419+00:00 c946f8c7e241 supervisord: saiserver insert: SAI_WARM_BOOT_READ_FILE:/var/cache/sai_warmboot.bin
2024-11-28T15:09:07.510420+00:00 c946f8c7e241 supervisord: saiserver insert: SAI_WARM_BOOT_WRITE_FILE:/var/cache/sai_warmboot.bin
2024-11-28T15:09:07.510422+00:00 c946f8c7e241 supervisord: saiserver insert: SAI_VS_SWITCH_TYPE:SAI_VS_SWITCH_TYPE_BCM56850
2024-11-28T15:09:07.510423+00:00 c946f8c7e241 supervisord: saiserver insert: SAI_VS_HOSTIF_USE_TAP_DEVICE:true
2024-11-28T15:09:07.510425+00:00 c946f8c7e241 supervisord: saiserver insert: SAI_VS_INTERFACE_LANE_MAP_FILE:/usr/share/sonic/hwsku/lanemap.ini
2024-11-28T15:09:07.510427+00:00 c946f8c7e241 supervisord: saiserver Failed to initialize SAI api: -15

$ docker images
REPOSITORY                        TAG        IMAGE ID       CREATED          SIZE
sc-thrift-server-trident2-saivs   bookworm   ab5ff0eb5c0f   33 minutes ago   2.12GB
sc-thrift-server-base             bookworm   149a8009d44b   34 minutes ago   2.12GB
sc-thrift-client                  bookworm   a1c0e06f2a24   43 minutes ago   1.15GB
sc-client                         bookworm   5d486c69e4ad   46 minutes ago   1.03GB

```