### PR TITLE
Ignore the non-SAI records in sairedis.rec files.

### DIFF
--- a/common/sai.py
+++ b/common/sai.py
@@ -568,6 +568,10 @@ class Sai():
         for cnt, record in records.items():
             print("#{}: {}".format(cnt, record))
             rec = record[0]
+            if rec[1] and not rec[1].startswith("SAI_"):
+                print("Ignored line {}: {}".format(cnt, rec))
+                continue
+
             if rec[0] == 'c':
                 attrs = []
                 if len(rec) > 2:
@@ -713,7 +717,7 @@ class Sai():
                 # It's expected that the previous command has failed
                 assert status in [rec[1], "SAI_STATUS_SUCCESS"], f"Expected fail reason is {rec[1]}. Actual fail reason is {status}"
             else:
-                print("Iggnored line {}: {}".format(cnt, rec))
+                print("Ignored line {}: {}".format(cnt, rec))
 
         print("Current SAI objects: {}".format(self.rec2vid))
 


### PR DESCRIPTION
sairec.py test failed due to unsuccessful try to set the SONiC flex port object from the sairedis.rec file.
```
self = <sai_npu.SaiNpuImpl object at 0x7af8bd47fc10>, action = 's', key = 'PORT_STAT_COUNTER'

    def __update_oid_key(self, action, key):                                                                                                                                            
        key_list = key.split(":", 1)
>       vid = key_list[1]
E       IndexError: list index out of range

/usr/local/lib/python3.11/dist-packages/saichallenger/common/sai.py:722: IndexError
--------------------------------------------------------------------------------- Captured stdout call ---------------------------------------------------------------------------------
#1: [['#', 'recording on: /var/log/swss/sairedis.rec']]
...
#32: [['q', 'attribute_capability', 'SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000', 'OBJECT_TYPE=SAI_OBJECT_TYPE_LAG', 'ATTR_ID=SAI_LAG_ATTR_TPID']]
Iggnored line 32: ['q', 'attribute_capability', 'SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000', 'OBJECT_TYPE=SAI_OBJECT_TYPE_LAG', 'ATTR_ID=SAI_LAG_ATTR_TPID']
#33: [['Q', 'attribute_capability', 'SAI_STATUS_NOT_IMPLEMENTED', 'OBJECT_TYPE=SAI_OBJECT_TYPE_LAG', 'ATTR_ID=SAI_LAG_ATTR_TPID', 'CREATE_IMP=false', 'SET_IMP=false', 'GET_IMP=false']]
Iggnored line 33: ['Q', 'attribute_capability', 'SAI_STATUS_NOT_IMPLEMENTED', 'OBJECT_TYPE=SAI_OBJECT_TYPE_LAG', 'ATTR_ID=SAI_LAG_ATTR_TPID', 'CREATE_IMP=false', 'SET_IMP=false', 'GET_IMP=false']
#34: [['q', 'attribute_capability', 'SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000', 'OBJECT_TYPE=SAI_OBJECT_TYPE_PORT', 'ATTR_ID=SAI_PORT_ATTR_EGRESS_SAMPLEPACKET_ENABLE']]
Iggnored line 34: ['q', 'attribute_capability', 'SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000', 'OBJECT_TYPE=SAI_OBJECT_TYPE_PORT', 'ATTR_ID=SAI_PORT_ATTR_EGRESS_SAMPLEPACKET_ENABLE']
#35: [['Q', 'attribute_capability', 'SAI_STATUS_NOT_IMPLEMENTED', 'OBJECT_TYPE=SAI_OBJECT_TYPE_PORT', 'ATTR_ID=SAI_PORT_ATTR_EGRESS_SAMPLEPACKET_ENABLE', 'CREATE_IMP=false', 'SET_IMP=false', 'GET_IMP=false']]
Iggnored line 35: ['Q', 'attribute_capability', 'SAI_STATUS_NOT_IMPLEMENTED', 'OBJECT_TYPE=SAI_OBJECT_TYPE_PORT', 'ATTR_ID=SAI_PORT_ATTR_EGRESS_SAMPLEPACKET_ENABLE', 'CREATE_IMP=false', 'SET_IMP=false', 'GET_IMP=false']
#36: [['g', 'SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000', 'SAI_SWITCH_ATTR_ECMP_HASH=oid:0x0']]
#37: [['G', 'SAI_STATUS_ATTR_NOT_IMPLEMENTED_0', '']]
#38: [['g', 'SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000', 'SAI_SWITCH_ATTR_LAG_HASH=oid:0x0']]
#39: [['G', 'SAI_STATUS_ATTR_NOT_IMPLEMENTED_0', '']]
#40: [['s', 'PORT_STAT_COUNTER', 'POLL_INTERVAL=1000', 'STATS_MODE=STATS_MODE_READ', 'FLEX_COUNTER_STATUS=disable']]
=================================================================================== warnings summary ===================================================================================
```