### PR TITLE
Fix the apply_rec() API for bulk create operations according.

### DIFF
--- a/common/sai.py
+++ b/common/sai.py
@@ -628,7 +628,7 @@ class Sai():
                     _, new_keys, _ = self.bulk_create(record[0][1], None, bulk_attrs, len(record)-1)
                     for idx in range(0, len(new_keys)):
                         if "oid:" in new_keys[idx]:
-                            self.rec2vid[new_keys[idx]] = new_keys[idx]
+                            self.rec2vid[record[idx + 1][0]] = new_keys[idx]
                 for idx in range(len(bulk_keys)):
                     self.create_rec_alias(record[0][1], bulk_attrs[idx], bulk_keys[idx])
 

--- a/common/sai.py
+++ b/common/sai.py
@@ -614,14 +614,21 @@ class Sai():
                     # Update OIDs in the key
                     key = self.__update_key(rec[0], key)
                     # Convert into ["sai-object-type", "key"]
-                    key = key.split(":", 1)[1]
+                    if ":" in key:
+                        key = key.split(":", 1)[1]
 
-                    if key.startswith("{"):
+                    if type(key) is dict or key.startswith("{"):
                         key = json.loads(key)
                     bulk_keys.append(key)
                     bulk_attrs.append(attrs)
 
-                self.bulk_create(record[0][1], bulk_keys, bulk_attrs)
+                if type(key) is dict or key.startswith("{"):
+                    self.bulk_create(record[0][1], bulk_keys, bulk_attrs)
+                else:
+                    _, new_keys, _ = self.bulk_create(record[0][1], None, bulk_attrs, len(record)-1)
+                    for idx in range(0, len(new_keys)):
+                        if "oid:" in new_keys[idx]:
+                            self.rec2vid[new_keys[idx]] = new_keys[idx]
                 for idx in range(len(bulk_keys)):
                     self.create_rec_alias(record[0][1], bulk_attrs[idx], bulk_keys[idx])
 
@@ -646,7 +653,8 @@ class Sai():
                     # Update OIDs in the key
                     key = self.__update_key(rec[0], key)
                     # Convert into ["sai-object-type", "key"]
-                    key = key.split(":", 1)[1]
+                    if ":" in key:
+                        key = key.split(":", 1)[1]
 
                     if key.startswith("{"):
                         key = json.loads(key)
@@ -669,7 +677,8 @@ class Sai():
                     # Update OIDs in the key
                     key = self.__update_key(rec[0], key)
                     # Convert into ["sai-object-type", "key"]
-                    key = key.split(":", 1)[1]
+                    if ":" in key:
+                        key = key.split(":", 1)[1]
 
                     if key.startswith("{"):
                         key = json.loads(key)


### PR DESCRIPTION
There were couple of errors seen during the sairec test run with the recording file generated on latest SONiC/SAI source code:
```
                    # Convert into "sai-object-type:key"
                    key = record[0][1] + ":" + record[idx + 1][0]
                    # Update OIDs in the key
                    key = self.__update_key(rec[0], key)
                    # Convert into ["sai-object-type", "key"]
>                   key = key.split(":", 1)[1]
E                   IndexError: list index out of range
...
Ignored line 131: ['a', 'APPLY_VIEW']
#132: [['A', 'SAI_STATUS_SUCCESS']]
Ignored line 132: ['A', 'SAI_STATUS_SUCCESS']
#133: [['C', 'SAI_OBJECT_TYPE_PORT'], ['oid:0x1000000000009', 'SAI_PORT_ATTR_HW_LANE_LIST=1:1', 'SAI_PORT_ATTR_SPEED=25000'], ['oid:0x100000000000a', 'SAI_PORT_ATTR_HW_LANE_LIST=1:2', 'SAI_PORT_ATTR_SPEED=25000'], ['oid:0x100000000000b', 'SAI_PORT_ATTR_HW_LANE_LIST=1:3', 'SAI_PORT_ATTR_SPEED=25000'], ['oid:0x100000000000c', 'SAI_PORT_ATTR_HW_LANE_LIST=1:4', 'SAI_PORT_ATTR_SPEED=25000'], ['oid:0x100000000000d', 'SAI_PORT_ATTR_HW_LANE_LIST=1:5', 'SAI_PORT_ATTR_SPEED=25000'], ['oid:0x100000000000e', 'SAI_PORT_ATTR_HW_LANE_LIST=1:6', 'SAI_PORT_ATTR_SPEED=25000'], ['oid:0x100000000000f', 'SAI_PORT_ATTR_HW_LANE_LIST=1:7', 'SAI_PORT_ATTR_SPEED=25000'], ['oid:0x1000000000010', 'SAI_PORT_ATTR_HW_LANE_LIST=1:8', 'SAI_PORT_ATTR_SPEED=25000']]
=================================================================================== warnings summary ===================================================================================
...

>               if key.startswith("{"):
E               AttributeError: 'dict' object has no attribute 'startswith'

/usr/local/lib/python3.11/dist-packages/saichallenger/common/sai.py:625: AttributeError
```