### PR TITLE
Replace keys as required by sai_deserialize_neighbor_entry() in sonic-sairedis.

### DIFF
--- a/common/sai_client/sai_redis_client/sai_redis_client.py
+++ b/common/sai_client/sai_redis_client/sai_redis_client.py
@@ -98,6 +98,11 @@ class SaiRedisClient(SaiClient):
             obj = obj.replace("bv_id", "bvid")
             obj = obj.replace("mac_address", "mac")
 
+        # Required by sai_deserialize_neighbor_entry() in sonic-sairedis.
+        if "ip_address" in obj:
+            obj = obj.replace("ip_address", "ip")
+            obj = obj.replace("rif_id", "rif")
+
         self.r.lpush("ASIC_STATE_KEY_VALUE_OP_QUEUE", obj, attrs, op)
         self.r.publish(self.asic_channel, "G")
 


### PR DESCRIPTION
Failed to create the neighbor entry:
```
(Pdb++) print (obj, attrs, do_assert)
SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip_address": "10.1.1.2", "rif_id": "oid:0x600000000001e", "switch_id": "oid:0x21000000000000"} ['SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS', '00:11:11:11:11:11'] True
(Pdb++) c
            )
...
        self.r.delete("GETRESPONSE_KEY_VALUE_OP_QUEUE")
    
>       assert len(status) == 3, f"SAI \"{op[1:]}\" operation failure!"
E       AssertionError: SAI "create" operation failure!
```
SAI headers neighbor entry definition:
```
/**
 * @brief Neighbor entry
 */
typedef struct _sai_neighbor_entry_t
{
    /**
     * @brief Switch ID
     *
     * @objects SAI_OBJECT_TYPE_SWITCH
     */
    sai_object_id_t switch_id;

    /**
     * @brief Router interface ID
     *
     * @objects SAI_OBJECT_TYPE_ROUTER_INTERFACE
     */
    sai_object_id_t rif_id;

    /**
     * @brief IP address
     */
    sai_ip_address_t ip_address;

} sai_neighbor_entry_t;
```

Redis expect the entry key in the following format:
```
2017-06-14.01:56:16.538038|c|SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip":"10.1.1.2","rif":"oid:0x600000000001e","switch_id":"oid:0x21000000000000"}|SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS=00:11:11:11:11:11
```