### PR TITLE
Updated actions/upload-artifact@v3 to v4

### DIFF
--- a/.github/workflows/sc-client-server-deb10.yml
+++ b/.github/workflows/sc-client-server-deb10.yml
@@ -134,13 +134,13 @@ jobs:
       run: git submodule update --init
     
     - name: Download client Docker image
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Client Image
     - name: Load client image
       run: docker load < sc-client.tar
     - name: Download server Docker image
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Server Image
     - name: Load server image

--- a/.github/workflows/sc-client-server-deb10.yml
+++ b/.github/workflows/sc-client-server-deb10.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Save server Docker image
       run: docker save sc-server-trident2-saivs > sc-server.tar
     - name: Upload server image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Server Image
         path: sc-server.tar
@@ -119,7 +119,7 @@ jobs:
     - name: Save client Docker image
       run: docker save sc-client > sc-client.tar
     - name: Upload client Docker image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Client Image
         path: sc-client.tar

--- a/.github/workflows/sc-client-server-deb11.yml
+++ b/.github/workflows/sc-client-server-deb11.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Save server Docker image
       run: docker save sc-server-trident2-saivs > sc-server.tar
     - name: Upload server image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Server Image
         path: sc-server.tar
@@ -118,7 +118,7 @@ jobs:
     - name: Save client Docker image
       run: docker save sc-client > sc-client.tar
     - name: Upload client Docker image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Client Image
         path: sc-client.tar

--- a/.github/workflows/sc-client-server-deb11.yml
+++ b/.github/workflows/sc-client-server-deb11.yml
@@ -133,13 +133,13 @@ jobs:
       run: git submodule update --init
     
     - name: Download client Docker image
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Client Image
     - name: Load client image
       run: docker load < sc-client.tar
     - name: Download server Docker image
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Server Image
     - name: Load server image


### PR DESCRIPTION
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/