### PR TITLE
Fixed importing of ASIC specific NPU module

### DIFF
--- a/common/sai_testbed.py
+++ b/common/sai_testbed.py
@@ -109,7 +109,7 @@ class SaiTestbed():
         self.skip_dataplane = skip_dataplane
 
     @staticmethod
-    def __import_module(root_path, module_name):
+    def import_module(root_path, module_name):
         module_specs = importlib.util.spec_from_file_location(module_name, os.path.join(root_path, f"{module_name}.py"))
         return module_specs.loader.load_module()
 
@@ -123,11 +123,11 @@ class SaiTestbed():
         asic_mod = None
         module_name = f"sai_{asic_type}"
         try:
-            asic_mod = SaiTestbed.__import_module(asic_dir, module_name)
+            asic_mod = SaiTestbed.import_module(asic_dir, module_name)
         except:
             logging.info("No {} specific module defined..".format(params["asic"]))
             try:
-                asic_mod = SaiTestbed.__import_module(asic_dir + "/../", module_name)
+                asic_mod = SaiTestbed.import_module(asic_dir + "/../", module_name)
             except:
                 logging.warning("No NPU specific module defined.")
 


### PR DESCRIPTION
This PR fixes spawning a custom NPU module through `SaiTestbed.spawn_asic()`:
```
(Pdb++) asic_mod = SaiTestbed.__import_module(asic_dir + "/../", module_name)
*** AttributeError: type object 'SaiTestbed' has no attribute '__import_module'
```

The `__import_module` method is stored in `SaiTestbed.__dict__` as `_SaiTestbed__import_module`.
This happens due to name mangling, a mechanism Python uses to avoid name conflicts in inheritance.
When you define a class method with double underscores (__method_name), Python automatically renames it to _ClassName__method_name.
```
print(dir(SaiTestbed))  
# Shows '_SaiTestbed__import_module' instead of '__import_module'

print(SaiTestbed.__dict__)  
# {'_SaiTestbed__import_module': <classmethod object at ...>}
```