### PR TITLE
Fixed "DeprecationWarning: the load_module()"

### DIFF
--- a/common/sai_dataplane/ptf/sai_ptf_dataplane.py
+++ b/common/sai_dataplane/ptf/sai_ptf_dataplane.py
@@ -149,7 +149,10 @@ class SaiPtfDataPlane(SaiDataPlane, TestCase):
     @staticmethod
     def __import_module(root_path, module_name):
         module_specs = importlib.util.find_spec(module_name, [root_path])
-        return module_specs.loader.load_module()
+        module = importlib.util.module_from_spec(module_specs)
+        sys.modules[module_name] = module
+        module_specs.loader.exec_module(module)
+        return module
 
     def init(self):
         global ptf

--- a/common/sai_testbed.py
+++ b/common/sai_testbed.py
@@ -3,6 +3,7 @@ import os
 import json
 import glob
 import logging
+import sys
 
 from saichallenger.common.sai_dut import SaiDut
 from saichallenger.common.sai_npu import SaiNpu
@@ -111,7 +112,10 @@ class SaiTestbed():
     @staticmethod
     def import_module(root_path, module_name):
         module_specs = importlib.util.spec_from_file_location(module_name, os.path.join(root_path, f"{module_name}.py"))
-        return module_specs.loader.load_module()
+        module = importlib.util.module_from_spec(module_specs)
+        sys.modules[module_name] = module
+        module_specs.loader.exec_module(module)
+        return module
 
     @staticmethod
     def spawn_asic(base_dir, cfg, asic_type="npu"):


### PR DESCRIPTION
This PR fixes a warning as follows:
```
 <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```