### PR TITLE
Fixed "Ubuntu 20.04 LTS runner will be removed on 2025-04-15" issue

### DIFF
--- a/.github/workflows/sc-client-deb10-publish.yml
+++ b/.github/workflows/sc-client-deb10-publish.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build-sc-client:
     name: Build SAI Challenger client image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Update submodules

--- a/.github/workflows/sc-client-deb11-publish.yml
+++ b/.github/workflows/sc-client-deb11-publish.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build-sc-client:
     name: Build SAI Challenger client image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Update submodules

--- a/.github/workflows/sc-client-server-deb10.yml
+++ b/.github/workflows/sc-client-server-deb10.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   build-sc-server:
     name: Build SAI Challenger server image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -85,7 +85,7 @@ jobs:
 
   build-sc-client:
     name: Build SAI Challenger client image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -127,7 +127,7 @@ jobs:
   run-sc-tests:
     name: Run SAI Challenger tests in client-server mode
     needs: [build-sc-client, build-sc-server]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Update submodules.

--- a/.github/workflows/sc-client-server-deb11.yml
+++ b/.github/workflows/sc-client-server-deb11.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   build-sc-server:
     name: Build SAI Challenger server image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -84,7 +84,7 @@ jobs:
 
   build-sc-client:
     name: Build SAI Challenger client image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -126,7 +126,7 @@ jobs:
   run-sc-tests:
     name: Run SAI Challenger tests in client-server mode
     needs: [build-sc-client, build-sc-server]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Update submodules.

--- a/.github/workflows/sc-server-deb10-publish.yml
+++ b/.github/workflows/sc-server-deb10-publish.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build-sc-server:
     name: Build SAI Challenger server image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Update submodules

--- a/.github/workflows/sc-server-deb11-publish.yml
+++ b/.github/workflows/sc-server-deb11-publish.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build-sc-server:
     name: Build SAI Challenger server image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Update submodules

--- a/.github/workflows/sc-standalone-deb10-publish.yml
+++ b/.github/workflows/sc-standalone-deb10-publish.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   build-sc-standalone:
     name: Build SAI Challenger standalone image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Update submodules

--- a/.github/workflows/sc-standalone-deb10.yml
+++ b/.github/workflows/sc-standalone-deb10.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   build-sc-stadalone:
     name: Build SAI Challenger standalone image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/sc-standalone-deb11-publish.yml
+++ b/.github/workflows/sc-standalone-deb11-publish.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   build-sc-standalone:
     name: Build SAI Challenger standalone image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Update submodules

--- a/.github/workflows/sc-standalone-deb11.yml
+++ b/.github/workflows/sc-standalone-deb11.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   build-sc-stadalone:
     name: Build SAI Challenger standalone image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/veth-create-host.sh
+++ b/veth-create-host.sh
@@ -11,7 +11,9 @@
 DOCKER1=$1
 DOCKER2=$2
 
-if [ -z $DOCKER1 ]; then
+mkdir -p /var/run/netns  # Ensure the directory exists
+
+if [ -z "$DOCKER1" ]; then
     echo "Server Docker name must be specified."
     exit 1
 fi
@@ -20,7 +22,7 @@ PID=$(docker inspect --format '{{ .State.Pid }}' $DOCKER1)
 DOCKER1_NETNS="$DOCKER1_$PID"
 ln -s /proc/$PID/ns/net /var/run/netns/$DOCKER1_NETNS
 
-if [ ! -z $DOCKER2 ]; then
+if [ ! -z "$DOCKER2" ]; then
     PID=$(docker inspect --format '{{ .State.Pid }}' $DOCKER2)
     DOCKER2_NETNS="$DOCKER2_$PID"
     ln -s /proc/$PID/ns/net /var/run/netns/$DOCKER2_NETNS
@@ -30,7 +32,7 @@ for num in {1..32}; do
     ip link add veth"$num" type veth peer name eth"$num" netns $DOCKER1_NETNS
     ip netns exec $DOCKER1_NETNS ip link set eth"$num" up
     ip link set veth"$num" up
-    if [ ! -z $DOCKER2 ]; then
+    if [ ! -z "$DOCKER2" ]; then
         ip link set dev veth"$num" netns $DOCKER2_NETNS
         ip netns exec $DOCKER2_NETNS ip link set veth"$num" up
     fi


### PR DESCRIPTION
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15.
For more details, see https://github.com/actions/runner-images/issues/11101