### PR TITLE
Fixed Buster environment build issue caused by pdbpp

### DIFF
--- a/dockerfiles/buster/Dockerfile
+++ b/dockerfiles/buster/Dockerfile
@@ -107,7 +107,7 @@ RUN echo "#mock" > /ptf/ptf && pip3 install /ptf
 COPY scripts/gen_attr_list /sai/gen_attr_list
 
 # Install SAI-C dependencies
-RUN pip3 install pytest pytest_dependency pytest-html aenum pdbpp macaddress click==8.0
+RUN pip3 install pytest pytest_dependency pytest-html aenum macaddress click==8.0
 RUN apt-get install -y python3-paramiko
 
 # Deploy SAI Challenger

--- a/dockerfiles/buster/Dockerfile.client
+++ b/dockerfiles/buster/Dockerfile.client
@@ -63,7 +63,7 @@ RUN git clone https://github.com/opencomputeproject/SAI.git \
         && rm -rf /sai/SAI
 
 # Install SAI-C dependencies
-RUN pip3 install pytest pytest_dependency pytest-html aenum pdbpp macaddress click==8.0 redis>=3.5.0
+RUN pip3 install pytest pytest_dependency pytest-html aenum macaddress click==8.0 redis>=3.5.0
 
 ARG NOSNAPPI
 RUN if [ "$NOSNAPPI" != "y" ]; then \


### PR DESCRIPTION
Fixed Buster environment build issue caused by pdbpp
```
root@6f3edd7d0062:/sai-challenger/tests# pip3 install pytest pytest_dependency pytest-html aenum pdbpp macaddress click==8.0 redis>=3.5.0 
  Could not find a version that satisfies the requirement fancycompleter>=0.11.0 (from pdbpp) (from versions: 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.6.1, 0.6.2, 0.6.3, 0.7, 0.8, 0.9.0, 0.9.1)
No matching distribution found for fancycompleter>=0.11.0 (from pdbpp)

```