### PR TITLE
Fixed FDB tests execution

### DIFF
--- a/.github/workflows/sc-client-server-deb11.yml
+++ b/.github/workflows/sc-client-server-deb11.yml
@@ -15,6 +15,7 @@ on:
       - 'scripts/**'
       - 'configs/**'
       - 'tests/**'
+      - 'topologies/**'
       - 'setup.py'
       - 'build.sh'
       - 'run.sh'

--- a/.github/workflows/sc-client-server-deb12.yml
+++ b/.github/workflows/sc-client-server-deb12.yml
@@ -16,6 +16,7 @@ on:
       - 'scripts/**'
       - 'configs/**'
       - 'tests/**'
+      - 'topologies/**'
       - 'setup.py'
       - 'build.sh'
       - 'run.sh'

--- a/.github/workflows/sc-client-server-deb13.yml
+++ b/.github/workflows/sc-client-server-deb13.yml
@@ -16,6 +16,7 @@ on:
       - 'scripts/**'
       - 'configs/**'
       - 'tests/**'
+      - 'topologies/**'
       - 'setup.py'
       - 'build.sh'
       - 'run.sh'

--- a/.github/workflows/sc-standalone-deb11.yml
+++ b/.github/workflows/sc-standalone-deb11.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/**'
       - 'configs/**'
       - 'tests/**'
+      - 'topologies/**'
       - 'setup.py'
       - 'build.sh'
       - 'run.sh'

--- a/.github/workflows/sc-standalone-deb12.yml
+++ b/.github/workflows/sc-standalone-deb12.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/**'
       - 'configs/**'
       - 'tests/**'
+      - 'topologies/**'
       - 'setup.py'
       - 'build.sh'
       - 'run.sh'

--- a/.github/workflows/sc-standalone-deb13.yml
+++ b/.github/workflows/sc-standalone-deb13.yml
@@ -14,6 +14,7 @@ on:
       - 'scripts/**'
       - 'configs/**'
       - 'tests/**'
+      - 'topologies/**'
       - 'setup.py'
       - 'build.sh'
       - 'run.sh'

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -31,8 +31,30 @@ def on_prev_test_failure(prev_test_failed, npu):
 
 @pytest.fixture(scope="module")
 def sai_ptf_topology(npu):
+    _detach_from_default(npu, list(range(len(npu.port_oids))))
+
     with saichallenger.topologies.sai_ptf_topology.config(npu) as topo:
         yield topo
+
+
+def _detach_from_default(npu, port_indices):
+    """
+    Detach ports from default VLAN 1 and remove default 1Q bridge ports.
+    """
+    for idx in port_indices:
+        bp = npu.dot1q_bp_oids[idx]
+        try:
+            # VLAN-member in VLAN 1
+            npu.remove_vlan_member(npu.default_vlan_oid, bp)
+        except Exception:
+            # nothing to remove (skipped)
+            pass
+        try:
+            # bridge-port
+            npu.remove(bp)
+        except Exception:
+            # nothing to remove (skipped)
+            pass
 
 
 def _fdb_entry_key(npu, vlan_oid, mac):

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -31,30 +31,8 @@ def on_prev_test_failure(prev_test_failed, npu):
 
 @pytest.fixture(scope="module")
 def sai_ptf_topology(npu):
-    _detach_from_default(npu, list(range(len(npu.port_oids))))
-
     with saichallenger.topologies.sai_ptf_topology.config(npu) as topo:
         yield topo
-
-
-def _detach_from_default(npu, port_indices):
-    """
-    Detach ports from default VLAN 1 and remove default 1Q bridge ports.
-    """
-    for idx in port_indices:
-        bp = npu.dot1q_bp_oids[idx]
-        try:
-            # VLAN-member in VLAN 1
-            npu.remove_vlan_member(npu.default_vlan_oid, bp)
-        except Exception:
-            # nothing to remove (skipped)
-            pass
-        try:
-            # bridge-port
-            npu.remove(bp)
-        except Exception:
-            # nothing to remove (skipped)
-            pass
 
 
 def _fdb_entry_key(npu, vlan_oid, mac):

--- a/topologies/sai_ptf_topology.py
+++ b/topologies/sai_ptf_topology.py
@@ -122,6 +122,7 @@ class SaiPtfTopologyMixin:
             setattr(self, "port%d" % i, npu.port_oids[i])
 
         self.remove_default_vlan_members()
+        self.remove_default_bridge_ports()
         self.create_sai_helper_topology()
 
     def teardown_ptf_topology(self) -> None:
@@ -135,7 +136,14 @@ class SaiPtfTopologyMixin:
         self.destroy_vlans_with_members()
         self.destroy_bridge_ports()
         self.destroy_lags_with_members()
+        self.restore_default_bridge_ports()
         self.restore_default_vlan_members()
+
+    def remove_default_bridge_ports(self) -> None:
+        """Remove default 1Q bridge ports."""
+        for idx in list(range(len(self.npu.port_oids))):
+            bp = self.npu.dot1q_bp_oids[idx]
+            self.npu.remove(bp)
 
     def remove_default_vlan_members(self) -> None:
         """Detach all ports from the default VLAN and save them for later restore."""
@@ -144,15 +152,30 @@ class SaiPtfTopologyMixin:
         self._saved_default_vlan_members = []
         for mbr_oid in mbr_oids:
             bp_oid = self.npu.get(mbr_oid, ["SAI_VLAN_MEMBER_ATTR_BRIDGE_PORT_ID"]).oid()
+            port_oid = self.npu.get(bp_oid, ["SAI_BRIDGE_PORT_ATTR_PORT_ID"]).oid()
             tag = self.npu.get(mbr_oid, ["SAI_VLAN_MEMBER_ATTR_VLAN_TAGGING_MODE"]).value()
-            self._saved_default_vlan_members.append({"bp_oid": bp_oid, "tagging": tag})
+            self._saved_default_vlan_members.append({"port_oid": port_oid, "tagging": tag})
             self.npu.remove(mbr_oid)
+
+    def restore_default_bridge_ports(self) -> None:
+        """Re-create default bridge ports."""
+        for rec in self._saved_default_vlan_members:
+            bp_oid = self.npu.create(
+                SaiObjType.BRIDGE_PORT,
+                [
+                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", rec["port_oid"],
+                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true"
+                ]
+            )
+            rec.update({"port_oid": bp_oid})
+        self.npu.dot1q_bp_oids = self.npu.get(self.npu.dot1q_br_oid, ["SAI_BRIDGE_ATTR_PORT_LIST"]).to_list()
 
     def restore_default_vlan_members(self) -> None:
         """Re-attach ports to the default VLAN as they were before setup."""
         for rec in self._saved_default_vlan_members:
             self.npu.create_vlan_member(
-                self.npu.default_vlan_oid, rec["bp_oid"], rec["tagging"]
+                self.npu.default_vlan_oid, rec["port_oid"], rec["tagging"]
             )
 
     @staticmethod


### PR DESCRIPTION
### Summary
Added function for deletion bridge ports before each test suite execution.
Previously FDB tests fail with error `SAI_STATUS_OBJECT_IN_USE` on HW environment.


### Test Results
=== VS environment ===
```
==================================================================================== test session starts ====================================================================================
collected 1 item                                                                                                                                                                            

test_fdb.py::TestFdbAttribute::test_fdb_attribute PASSED                                                                                                                              [100%]

==================================================================================== 1 passed in 11.61s =====================================================================================
```

=== HW environment ===
**_Before fix_**
```
==================================================================================== test session starts ====================================================================================
collected 1 item                                                                                                                                                                            

test_fdb.py::TestFdbStaticMac::test_fdb_self_forwarding_drop ERROR                                                                                                                    [100%]



E           AssertionError: create(SAI_OBJECT_TYPE_LAG_MEMBER:oid:0x1b000000000929, ["SAI_LAG_MEMBER_ATTR_LAG_ID", "oid:0x2000000000927", "SAI_LAG_MEMBER_ATTR_PORT_ID", "oid:0x1000000000529"]) --> [b'Sgetresponse', b'[]', 'SAI_STATUS_OBJECT_IN_USE']

/usr/local/lib/python3.11/dist-packages/saichallenger/common/sai_client/sai_redis_client/sai_redis_client.py:151: AssertionError
================================================================================== short test summary info ==================================================================================
ERROR test_fdb.py::TestFdbStaticMac::test_fdb_self_forwarding_drop - AssertionError: create(SAI_OBJECT_TYPE_LAG_MEMBER:oid:0x1b000000000929, ["SAI_LAG_MEMBER_ATTR_LAG_ID", "oid:0x2000000000927", "SAI_LAG_MEMBER_ATTR_PORT_ID", "oid:0x1000000000529"]) -->...
================================================================================ 1 error in 83.96s (0:01:23) ================================================================================
```

**_After fix_**
```
==================================================================================== test session starts ====================================================================================
collected 1 item                                                                                                                                                                            

test_fdb.py::TestFdbStaticMac::test_fdb_self_forwarding_drop PASSED                                                                                                                   [100%]

=========================================================================== 1 passed in 78.21s (0:01:18) ===========================================================================
```