### PR TITLE
Add flush API for SaiPtfDataPlane

### DIFF
--- a/common/sai_dataplane/ptf/sai_ptf_dataplane.py
+++ b/common/sai_dataplane/ptf/sai_ptf_dataplane.py
@@ -255,3 +255,7 @@ class SaiPtfDataPlane(SaiDataPlane, TestCase):
 
     def teardown(self):
         self.tearDown()
+        
+    def flush(self):
+        if self.dataplane is not None:
+            self.dataplane.flush()


### PR DESCRIPTION
Add flush API for `SaiPtfDataPlane` that is required by some migrated PTF  tests such as `test_fdb.py::TestFdbFlush`:

```sh
============================================================================ short test summary info ============================================================================
FAILED test_fdb.py::TestFdbFlush::test_flush_all_per_vlan - AttributeError: 'SaiPtfDataPlane' object has no attribute 'flush'
============================================================================== 1 failed in 31.15s ===============================================================================
```