### PR TITLE
fix tests in TestFdbNoLearn

### DIFF
--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -284,12 +284,10 @@ class TestFdbNoLearn:
         try:
             npu.set(self.vlan_oid, ["SAI_VLAN_ATTR_LEARN_DISABLE", "true"])
             send_packet(dataplane, self.dev_port0, pkt)
-            verify_packets(dataplane, tag_pkt, [self.dev_port1])
-            verify_packet_any_port(dataplane, pkt, self.lag_ports)
+            verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[self.dev_port1], self.lag_ports])
 
             send_packet(dataplane, self.dev_port1, tag_chck_pkt)
-            verify_packets(dataplane, chck_pkt, [self.dev_port0])
-            verify_packet_any_port(dataplane, chck_pkt, self.lag_ports)
+            verify_each_packet_on_multiple_port_lists(dataplane, [chck_pkt, chck_pkt], [[self.dev_port0], self.lag_ports])
         finally:
             npu.flush_fdb_entries(
                 npu.switch_oid,
@@ -316,12 +314,10 @@ class TestFdbNoLearn:
         try:
             npu.set(self.vlan_oid, ["SAI_VLAN_ATTR_LEARN_DISABLE", "true"])
             send_packet(dataplane, self.lag_ports[1], pkt)
-            verify_packets(dataplane, pkt, [self.dev_port0])
-            verify_packets(dataplane, tag_pkt, [self.dev_port1])
+            verify_each_packet_on_multiple_port_lists(dataplane, [pkt, tag_pkt], [[self.dev_port0], [self.dev_port1]])
 
             send_packet(dataplane, self.dev_port1, tag_chck_pkt)
-            verify_packets(dataplane, chck_pkt, [self.dev_port0])
-            verify_packet_any_port(dataplane, chck_pkt, self.lag_ports)
+            verify_each_packet_on_multiple_port_lists(dataplane, [chck_pkt, chck_pkt], [[self.dev_port0], self.lag_ports])
         finally:
             npu.flush_fdb_entries(
                 npu.switch_oid,
@@ -348,12 +344,10 @@ class TestFdbNoLearn:
         try:
             npu.set(self.port0_bp, ["SAI_BRIDGE_PORT_ATTR_FDB_LEARNING_MODE", "SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DISABLE"])
             send_packet(dataplane, self.dev_port0, pkt)
-            verify_packets(dataplane, tag_pkt, [self.dev_port1])
-            verify_packet_any_port(dataplane, pkt, self.lag_ports)
+            verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[self.dev_port1], self.lag_ports])
 
             send_packet(dataplane, self.dev_port1, tag_chck_pkt)
-            verify_packets(dataplane, chck_pkt, [self.dev_port0])
-            verify_packet_any_port(dataplane, chck_pkt, self.lag_ports)
+            verify_each_packet_on_multiple_port_lists(dataplane, [chck_pkt, chck_pkt], [[self.dev_port0], self.lag_ports])
         finally:
             npu.flush_fdb_entries(
                 npu.switch_oid,
@@ -380,12 +374,10 @@ class TestFdbNoLearn:
         try:
             npu.set(self.lag1_bp, ["SAI_BRIDGE_PORT_ATTR_FDB_LEARNING_MODE", "SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DISABLE"])
             send_packet(dataplane, self.lag_ports[1], pkt)
-            verify_packets(dataplane, pkt, [self.dev_port0])
-            verify_packets(dataplane, tag_pkt, [self.dev_port1])
+            verify_each_packet_on_multiple_port_lists(dataplane, [pkt, tag_pkt], [[self.dev_port0], [self.dev_port1]])
 
             send_packet(dataplane, self.dev_port1, tag_chck_pkt)
-            verify_packets(dataplane, chck_pkt, [self.dev_port0])
-            verify_packet_any_port(dataplane, chck_pkt, self.lag_ports)
+            verify_each_packet_on_multiple_port_lists(dataplane, [chck_pkt, chck_pkt], [[self.dev_port0], self.lag_ports])
         finally:
             npu.flush_fdb_entries(
                 npu.switch_oid,
@@ -396,6 +388,14 @@ class TestFdbNoLearn:
             )
             npu.set(self.lag1_bp, ["SAI_BRIDGE_PORT_ATTR_FDB_LEARNING_MODE", "SAI_BRIDGE_PORT_FDB_LEARNING_MODE_HW"])
 
+    @pytest.mark.skip(
+        reason=(
+            "The original PTF test does not make sense: traffic is sent on a port "
+            "with no bridge port, so it should be dropped, not flooded. "
+            "This test should be removed or rewritten. "
+            "Before removing a bridge port, its VLAN membership should be removed first."
+        )
+    )
     def test_removed_bp_no_learn(self, npu, dataplane):
         """
         Description:
@@ -444,6 +444,13 @@ class TestFdbNoLearn:
             _refresh_topo_vlan_member(topo, "vlan10_member0", new_member)
             self.vlan10_member0 = new_member
 
+    @pytest.mark.skip(
+        reason=(
+            "The original PTF test does not make sense: traffic is sent on a port "
+            "with no bridge port, so it should be dropped, not flooded. "
+            "This test should be removed or rewritten. "
+        )
+    )
     def test_no_bp_no_learn(self, npu, dataplane):
         """
         Description:


### PR DESCRIPTION
Fix tests in `test_fdb::TestFdbNoLearn`. Changes include the following:
* fix test cases that have two consecutive `verify_packet*` function calls. First call of `verify_packet*` flushed packet queues for other interfaces, which caused second call to fail (original PTF test also uses `verify_each_packet_on_multiple_port_lists` in those testcase)
* skip two test cases that are likely incorrect

## Before fix
```sh
============================================================================ short test summary info ============================================================================
FAILED test_fdb.py::TestFdbNoLearn::test_vlan_port_no_learn - AssertionError: Did not receive expected packet on any of ports [4, 5, 6] for device 0.
======================================================================== 1 failed, 3 warnings in 31.66s =========================================================================

pytest --testbed=sainpu_marvell_redis -v test_fdb.py::TestFdbNoLearn::test_no_bp_no_learn --traffic
============================================================================ short test summary info ============================================================================
FAILED test_fdb.py::TestFdbNoLearn::test_no_bp_no_learn - AssertionError: False is not true : Did not receive pkt on one of ports [[0], [1], [4, 5, 6]] for device 0
======================================================================== 1 failed, 2 warnings in 38.84s =========================================================================
```
## After fix
```sh
test_fdb.py::TestFdbNoLearn::test_vlan_port_no_learn PASSED                                                                                                               [ 16%]
test_fdb.py::TestFdbNoLearn::test_vlan_lag_no_learn PASSED                                                                                                                [ 33%]
test_fdb.py::TestFdbNoLearn::test_bp_port_no_learn PASSED                                                                                                                 [ 50%]
test_fdb.py::TestFdbNoLearn::test_bp_lag_no_learn PASSED                                                                                                                  [ 66%]
test_fdb.py::TestFdbNoLearn::test_removed_bp_no_learn SKIPPED (The original PTF test does not make sense: traffic is sent on a port with no bridge port, so it should...) [ 83%]
test_fdb.py::TestFdbNoLearn::test_no_bp_no_learn SKIPPED (The original PTF test does not make sense: traffic is sent on a port with no bridge port, so it should be d...) [100%]
=================================================================== 4 passed, 2 skipped, 8 warnings in 42.35s ===================================================================
```
