### PR TITLE
Recreate topology on previous test failure and run setup_teardown fixture once per test method

### DIFF
--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -23,16 +23,49 @@ def skip_all(testbed_instance):
         pytest.skip('invalid for "{}" testbed'.format(testbed.name))
 
 
-@pytest.fixture(autouse=True)
-def on_prev_test_failure(prev_test_failed, npu):
-    if prev_test_failed:
-        npu.reset()
+class _SaiPtfTopologyHolder:
+    """Module-scoped PTF topology with reset + recreate on prior test failure."""
+
+    def __init__(self, npu):
+        self._npu = npu
+        self._ctx = None
+        self.topo = None
+
+    def create(self):
+        self._ctx = saichallenger.topologies.sai_ptf_topology.config(self._npu)
+        self.topo = self._ctx.__enter__()
+        return self.topo
+
+    def destroy(self):
+        if self._ctx is not None:
+            self._ctx.__exit__(None, None, None)
+            self._ctx = None
+            self.topo = None
+
+    def recreate(self):
+        self._ctx = None
+        self.topo = None
+        self._npu.reset()
+        return self.create()
 
 
 @pytest.fixture(scope="module")
-def sai_ptf_topology(npu):
-    with saichallenger.topologies.sai_ptf_topology.config(npu) as topo:
-        yield topo
+def sai_ptf_topo_holder(npu):
+    holder = _SaiPtfTopologyHolder(npu)
+    holder.create()
+    yield holder
+    holder.destroy()
+
+
+@pytest.fixture(autouse=True)
+def on_prev_test_failure(prev_test_failed, sai_ptf_topo_holder):
+    if prev_test_failed:
+        sai_ptf_topo_holder.recreate()
+
+
+@pytest.fixture
+def sai_ptf_topology(sai_ptf_topo_holder, on_prev_test_failure):
+    return sai_ptf_topo_holder.topo
 
 
 def _fdb_entry_key(npu, vlan_oid, mac):
@@ -79,7 +112,7 @@ class TestFdbStaticMac:
     """
     Topology for FdbStaticMacTest: provides VLAN 10, lag1, bridge ports and PVIDs.
     """
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown(self, request, npu, sai_ptf_topology):
         topo = sai_ptf_topology
         request.cls.vlan_oid = topo.vlan10
@@ -172,7 +205,7 @@ class TestFdbAttribute:
     """
     Topology for FdbAttributeTest: provides VLAN 10, bridge port and test MAC address.
     """
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown(self, request, npu, sai_ptf_topology):
         topo = sai_ptf_topology
         request.cls.vlan_oid = topo.vlan10
@@ -220,7 +253,7 @@ class TestFdbNoLearn:
     """
     Topology for FdbNoLearnTest: VLAN 10 with port0/port1 and lag1.
     """
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown(self, request, npu, sai_ptf_topology):
         topo = sai_ptf_topology
         request.cls._topo = topo
@@ -496,7 +529,7 @@ class TestFdbLearn:
     """
     Topology for FdbLearnTest: VLAN 10 ports + lag1 and temporarily added lag2 (tagged).
     """
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown(self, request, npu, sai_ptf_topology):
         topo = sai_ptf_topology
         request.cls._topo = topo
@@ -894,7 +927,7 @@ class TestFdbMacMove:
     Topology for FdbMacMoveTest: VLAN 10 with port1 untagged, extra access port24,
     static chck_mac on port24_bp, and lag10 (ports 25–27) in VLAN 10.
     """
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown(self, request, npu, sai_ptf_topology):
         topo = sai_ptf_topology
         if len(npu.port_oids) < 28:
@@ -1105,7 +1138,7 @@ class TestFdbFlush:
     Topology for FdbFlushTest: port1/port3/lag2 retagged like PTF, trunk stub on port24, dual flood+forward checks.
     """
 
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown(self, request, npu, sai_ptf_topology):
         topo = sai_ptf_topology
         if len(npu.port_oids) <= 24:
@@ -2315,7 +2348,7 @@ class TestFdbAge:
     Topology for FdbAgeTest: global FDB aging time, extra VLAN10 member on port24,
     static vrf_mac on port24_bp for routed verification traffic toward CPU path.
     """
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown(self, request, npu, sai_ptf_topology):
         topo = sai_ptf_topology
         if len(npu.port_oids) < 25:
@@ -2570,7 +2603,7 @@ class TestFdbMiss:
     Topology for FdbMissTest: VLAN 100 on ports 24–26, hostif trap group (queue 4) with ARP + LLDP traps.
     """
 
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown(self, request, npu, sai_ptf_topology):
         if len(npu.port_oids) <= 26:
             pytest.skip("FdbMissTest requires physical port indices 24–26 (27 ports)")
@@ -2996,7 +3029,7 @@ class TestFdbEvent:
     """
     Topology for FdbEventTest: validate FDB attributes on learn/age/move/flush/delete.
     """
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown(self, request, npu, sai_ptf_topology):
         topo = sai_ptf_topology
         request.cls.vlan_oid = topo.vlan10

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -24,8 +24,9 @@ def skip_all(testbed_instance):
 
 
 class _SaiPtfTopologyHolder:
-    """Module-scoped PTF topology with reset + recreate on prior test failure."""
-
+    """
+    Module-scoped PTF topology with reset + recreate on prior test failure.
+    """
     def __init__(self, npu):
         self._npu = npu
         self._ctx = None

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -26,8 +26,9 @@ def skip_all(testbed_instance):
 
 
 class _SaiPtfTopologyHolder:
-    """Module-scoped PTF topology with reset + recreate on prior test failure."""
-
+    """
+    Module-scoped PTF topology with reset + recreate on prior test failure.
+    """
     def __init__(self, npu):
         self._npu = npu
         self._ctx = None

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -25,16 +25,49 @@ def skip_all(testbed_instance):
         pytest.skip('invalid for "{}" testbed'.format(testbed.name))
 
 
-@pytest.fixture(autouse=True)
-def on_prev_test_failure(prev_test_failed, npu):
-    if prev_test_failed:
-        npu.reset()
+class _SaiPtfTopologyHolder:
+    """Module-scoped PTF topology with reset + recreate on prior test failure."""
+
+    def __init__(self, npu):
+        self._npu = npu
+        self._ctx = None
+        self.topo = None
+
+    def create(self):
+        self._ctx = saichallenger.topologies.sai_ptf_topology.config(self._npu)
+        self.topo = self._ctx.__enter__()
+        return self.topo
+
+    def destroy(self):
+        if self._ctx is not None:
+            self._ctx.__exit__(None, None, None)
+            self._ctx = None
+            self.topo = None
+
+    def recreate(self):
+        self._ctx = None
+        self.topo = None
+        self._npu.reset()
+        return self.create()
 
 
 @pytest.fixture(scope="module")
-def sai_ptf_topology(npu):
-    with saichallenger.topologies.sai_ptf_topology.config(npu) as topo:
-        yield topo
+def sai_ptf_topo_holder(npu):
+    holder = _SaiPtfTopologyHolder(npu)
+    holder.create()
+    yield holder
+    holder.destroy()
+
+
+@pytest.fixture(autouse=True)
+def on_prev_test_failure(prev_test_failed, sai_ptf_topo_holder):
+    if prev_test_failed:
+        sai_ptf_topo_holder.recreate()
+
+
+@pytest.fixture
+def sai_ptf_topology(sai_ptf_topo_holder, on_prev_test_failure):
+    return sai_ptf_topo_holder.topo
 
 
 def _vlan_data(vlan_id, ports, untagged, large_port):
@@ -75,7 +108,7 @@ def _vlan_stats_map(npu, vlan_oid):
 
 
 class TestL2Vlan:
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_teardown(self, request, npu, sai_ptf_topology):
         topo = sai_ptf_topology
         if len(npu.port_oids) < 32:


### PR DESCRIPTION
## Old behavior
When a test failed, the NPU was reset without recreating the topology, causing all subsequent tests to fail. In addition, the test class `setup_teardown` fixture was executed only once per test class. If a test method within the class failed, the fixture was not run again, leaving the test environment in an inconsistent state and causing subsequent test methods in the same class to fail.

## New behavior
When a test fails, the NPU is reset and the topology is recreated before the next test is executed. Additionally, the test class `setup_teardown` fixture is now executed once per test method instead of once per test class

As a result, tests are isolated from failures in previous test methods. However, the overall test execution time increases because `setup_teardown` is invoked for every test method