### PR TITLE
Update SAI-C to SONiC 202605 & SAI 1.18.1

### DIFF
--- a/common/sai.py
+++ b/common/sai.py
@@ -417,7 +417,7 @@ class Sai():
                                 "sai_acl_chain_list_t", "sai_port_pam4_eye_values_list_t",
                                 "sai_prbs_per_lane_rx_state_list_t", "sai_prbs_per_lane_bit_error_rate_list_t",
                                 "sai_prbs_per_lane_rx_status_list_t", "sai_pointer_t", 
-                                "sai_uint16_range_t", "sai_uint8_range_t"
+                                "sai_uint16_range_t", "sai_uint8_range_t", "sai_timespec_t"
                             ]
         if attr_type == "sai_object_list_t":
             status, data = self.get(obj, [attr, "1:oid:0x0"], do_assert)

--- a/sai.env
+++ b/sai.env
@@ -1,15 +1,15 @@
 # The sonic-swss-common and sonic-sairedis commits were taken from
-# sonic-buildimage master as of Feb 19, 2026
+# sonic-buildimage 202605 as of Jun 25, 2026
 #
-# https://github.com/sonic-net/sonic-buildimage/tree/736a156
+# https://github.com/sonic-net/sonic-buildimage/tree/ec2aea9
 
-SWSS_COMMON_ID=eaaa592
-SAIREDIS_ID=566c04a
+SWSS_COMMON_ID=240a31
+SAIREDIS_ID=f7316af
 
 # SAI version:
-#   v1.18.0 
-#   Jan 15, 2026
+#   v1.18.1 
+#   Mar 31, 2026
 
 SAI_URL=https://github.com/opencomputeproject/SAI.git
-SAI_ID=c72635e
+SAI_ID=c67f115
  


### PR DESCRIPTION
## Summary

Align SAI-Challenger dependencies with sonic-buildimage 202605 and SAI v1.18.1.

Update `sai.env` commit pins:

- `SWSS_COMMON_ID`: eaaa592 → 240a31
- `SAIREDIS_ID`: 566c04a → f7316af
- `SAI_ID`: c72635e → c67f115 (v1.18.1, Mar 31 2026)


Add `sai_timespec_t` to `unsupported_types` in `get_by_type()` to avoid syncd crashes when running `test_switch_ut` against new PTP switch attributes introduced in SAI 1.18.1 (e.g. `SAI_SWITCH_ATTR_PTP_TIME_OFFSET`).
