### PR TITLE
Add support of SAI warm boot testing

### DIFF
--- a/.github/workflows/sc-client-server-deb11.yml
+++ b/.github/workflows/sc-client-server-deb11.yml
@@ -175,6 +175,8 @@ jobs:
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_fdb.py test_vlan.py
     - name: Run flex counters test cases
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v -k "test_flex_counters"
+    - name: Run warm reboot test cases
+      run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_warm_reboot.py
     - name: Run unit tests
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v ut/test_acl_ut.py ut/test_bridge_ut.py ut/test_vrf_ut.py ut/test_port_ut.py ut/test_fdb_ut.py ut/test_lag_ut.py
     - name: Run unit tests

--- a/.github/workflows/sc-client-server-deb12.yml
+++ b/.github/workflows/sc-client-server-deb12.yml
@@ -177,6 +177,8 @@ jobs:
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_fdb.py test_vlan.py
     - name: Run flex counters test cases
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v -k "test_flex_counters"
+    - name: Run warm reboot test cases
+      run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_warm_reboot.py
     - name: Run unit tests
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v ut/test_acl_ut.py ut/test_bridge_ut.py ut/test_vrf_ut.py ut/test_port_ut.py ut/test_fdb_ut.py ut/test_lag_ut.py
     - name: Run unit tests

--- a/.github/workflows/sc-client-server-deb13.yml
+++ b/.github/workflows/sc-client-server-deb13.yml
@@ -177,6 +177,8 @@ jobs:
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_fdb.py test_vlan.py
     - name: Run flex counters test cases
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v -k "test_flex_counters"
+    - name: Run warm reboot test cases
+      run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_warm_reboot.py
     - name: Run unit tests
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v ut/test_acl_ut.py ut/test_bridge_ut.py ut/test_vrf_ut.py ut/test_port_ut.py ut/test_fdb_ut.py ut/test_lag_ut.py
     - name: Run unit tests

--- a/.github/workflows/sc-standalone-deb11.yml
+++ b/.github/workflows/sc-standalone-deb11.yml
@@ -76,6 +76,8 @@ jobs:
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_fdb.py test_vlan.py
     - name: Run flex counters test cases
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_flex_counters"
+    - name: Run warm reboot test cases
+      run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_warm_reboot.py
     - name: Run sairedis tests
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_sairec"
     - name: Run unit tests
@@ -103,7 +105,9 @@ jobs:
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_fdb.py test_vlan.py
     - name: Run thrift flex counters test cases
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v -k "test_flex_counters"
-    - name: Run thift data-driven tests
+    - name: Run thrift warm reboot test cases
+      run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_warm_reboot.py
+    - name: Run thrift data-driven tests
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_l2_basic_dd.py
     - name: Run thrift unit tests
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v ut/test_vrf_ut.py ut/test_bridge_ut.py ut/test_acl_ut.py ut/test_fdb_ut.py ut/test_lag_ut.py

--- a/.github/workflows/sc-standalone-deb12.yml
+++ b/.github/workflows/sc-standalone-deb12.yml
@@ -76,6 +76,8 @@ jobs:
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_fdb.py test_vlan.py
     - name: Run flex counters test cases
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_flex_counters"
+    - name: Run warm reboot test cases
+      run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_warm_reboot.py
     - name: Run sairedis tests
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_sairec"
     - name: Run unit tests
@@ -103,7 +105,9 @@ jobs:
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_fdb.py test_vlan.py
     - name: Run thrift flex counters test cases
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v -k "test_flex_counters"
-    - name: Run thift data-driven tests
+    - name: Run thrift warm reboot test cases
+      run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_warm_reboot.py
+    - name: Run thrift data-driven tests
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_l2_basic_dd.py
     - name: Run thrift unit tests
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v ut/test_vrf_ut.py ut/test_bridge_ut.py ut/test_acl_ut.py ut/test_fdb_ut.py ut/test_lag_ut.py

--- a/.github/workflows/sc-standalone-deb13.yml
+++ b/.github/workflows/sc-standalone-deb13.yml
@@ -76,6 +76,8 @@ jobs:
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_fdb.py test_vlan.py
     - name: Run flex counters test cases
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_flex_counters"
+    - name: Run warm reboot test cases
+      run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_warm_reboot.py
     - name: Run sairedis tests
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_sairec"
     - name: Run unit tests
@@ -103,7 +105,9 @@ jobs:
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_fdb.py test_vlan.py
     - name: Run thrift flex counters test cases
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v -k "test_flex_counters"
-    - name: Run thift data-driven tests
+    - name: Run thrift warm reboot test cases
+      run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_warm_reboot.py
+    - name: Run thrift data-driven tests
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_l2_basic_dd.py
     - name: Run thrift unit tests
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v ut/test_vrf_ut.py ut/test_bridge_ut.py ut/test_acl_ut.py ut/test_fdb_ut.py ut/test_lag_ut.py

--- a/common/sai.py
+++ b/common/sai.py
@@ -346,6 +346,11 @@ class Sai():
     def del_flex_counter(self, oid, counter_table="COUNTERS"):
         return self.sai_client.del_flex_counter(oid, counter_table)
 
+    def perform_warm_reboot(self, pre_tout=30, warm_tout=30, after_warm_tout=5):
+        self.sai_client.pre_shutdown(tout=pre_tout)
+        self.sai_client.warm_shutdown(tout=warm_tout)
+        self.sai_client.verify_restore_after_warm_shutdown(tout=after_warm_tout)
+    
     # Flush FDB
     def flush_fdb_entries(self, obj, attrs=None):
         self.sai_client.flush_fdb_entries(obj, attrs)

--- a/common/sai_client/sai_client.py
+++ b/common/sai_client/sai_client.py
@@ -76,6 +76,15 @@ class SaiClient:
     def del_flex_counter(self, oid, counter_table="COUNTERS"):
         raise NotImplementedError
 
+    def pre_shutdown(self, tout=30):
+        raise NotImplementedError
+    
+    def warm_shutdown(self, tout=30):
+        raise NotImplementedError
+
+    def verify_restore_after_warm_shutdown(self, tout=5):
+        raise NotImplementedError
+
     # Flush FDB
     def flush_fdb_entries(self, obj, attrs=None):
         raise NotImplementedError

--- a/common/sai_client/sai_redis_client/sai_redis_client.py
+++ b/common/sai_client/sai_redis_client/sai_redis_client.py
@@ -48,6 +48,7 @@ class SaiRedisClient(SaiClient):
         self.loglevel_db = redis.Redis(host=self.server_ip, port=self.port, db=3)
         self.counters_db = redis.Redis(host=self.server_ip, port=self.port, db=2, decode_responses=True)
         self.flex_counter_db = redis.Redis(host=self.server_ip, port=self.port, db=5, decode_responses=True)
+        self.state_db = redis.Redis(host=self.server_ip, port=self.port, db=6, decode_responses=True)
 
     def cleanup(self):
         '''
@@ -568,6 +569,53 @@ class SaiRedisClient(SaiClient):
     def del_flex_counter(self, oid, counter_table="COUNTERS"):
         counter = counter_table + ":" + oid
         return self.counters_db.delete(counter)
+
+    def pre_shutdown(self, tout=30):
+        pre_shutdown_msg = json.dumps(["PRE-SHUTDOWN", "PRE-SHUTDOWN"])
+        self.r.publish("RESTARTQUERY", pre_shutdown_msg)
+
+        # wait for pre-shutdown to succeed
+        successful_pre_shutdown = False
+        state = None
+        for i in range(tout + 1):
+            state = self.state_db.hget("WARM_RESTART_TABLE|warm-shutdown", "state")
+            if state == "pre-shutdown-succeeded":
+                successful_pre_shutdown = True
+                break
+            if i < tout:
+                time.sleep(1)
+
+        assert successful_pre_shutdown, f"Pre-shutdown failed: {state}"
+    
+    def warm_shutdown(self, tout=30):
+        # set WARM_RESTART_ENABLE_TABLE|syncd enable=true so that syncd sets boot type to warm
+        # after shutdown
+        self.state_db.hset("WARM_RESTART_ENABLE_TABLE|syncd", "enable", "true")
+
+        warm_shutdown_msg = json.dumps(["WARM", "WARM"])
+        self.r.publish("RESTARTQUERY", warm_shutdown_msg)
+
+        # wait for warm-shutdown to succeed
+        successful_warm_shutdown = False
+        state = None
+        for i in range(tout + 1):
+            state = self.state_db.hget("WARM_RESTART_TABLE|warm-shutdown", "state")
+            if state == "warm-shutdown-succeeded":
+                successful_warm_shutdown = True
+                break
+            if i < tout:
+                time.sleep(1)
+
+        assert successful_warm_shutdown, f"Warm-shutdown failed: {state}"
+
+        # clear state as we won't need it anymore
+        self.state_db.hdel("WARM_RESTART_TABLE|warm-shutdown", "state")
+
+    def verify_restore_after_warm_shutdown(self, tout=5):
+        self.__assert_syncd_running()
+        # syncd is running, but it may have not restored state before warm-shutdown
+        time.sleep(tout)
+
 
     def flush_fdb_entries(self, obj, attrs=None):
         """

--- a/common/sai_npu.py
+++ b/common/sai_npu.py
@@ -105,6 +105,46 @@ class SaiNpu(Sai):
         attr = []
         self.init(attr)
 
+    def perform_warm_reboot(self, pre_tout=30, warm_tout=30, after_warm_tout=5):
+        # disable FDB aging and learning for the switch and bridge ports
+        switch_fdb_aging_time = self.get(self.switch_oid, ["SAI_SWITCH_ATTR_FDB_AGING_TIME"]).value()
+        self.set(self.switch_oid, ["SAI_SWITCH_ATTR_FDB_AGING_TIME", "0"], do_assert=True)
+        for bp_oid in self.dot1q_bp_oids:
+            self.set(bp_oid, ["SAI_BRIDGE_PORT_ATTR_FDB_LEARNING_MODE", "SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DISABLE"], do_assert=True)
+
+        super().perform_warm_reboot(pre_tout=pre_tout, warm_tout=warm_tout, after_warm_tout=after_warm_tout)
+        self._verify_warm_boot()
+
+        # restore FDB aging and learning for the switch and bridge ports
+        for bp_oid in self.dot1q_bp_oids:
+            self.set(bp_oid, ["SAI_BRIDGE_PORT_ATTR_FDB_LEARNING_MODE", "SAI_BRIDGE_PORT_FDB_LEARNING_MODE_HW"], do_assert=True)
+        self.set(self.switch_oid, ["SAI_SWITCH_ATTR_FDB_AGING_TIME", switch_fdb_aging_time], do_assert=True)
+
+
+    
+    def _verify_warm_boot(self):
+        switch_type = self.get(self.switch_oid, ["SAI_SWITCH_ATTR_TYPE"]).value()
+        assert switch_type == "SAI_SWITCH_TYPE_NPU", "Switch type is not NPU"
+
+        dot1q_br_oid = self.get(self.switch_oid, ["SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_ID"]).oid()
+        assert dot1q_br_oid == self.dot1q_br_oid, "Default .1Q bridge ID is not the same"
+
+        default_vlan_oid = self.get(self.switch_oid, ["SAI_SWITCH_ATTR_DEFAULT_VLAN_ID"]).oid()
+        assert default_vlan_oid == self.default_vlan_oid, "Default VLAN ID is not the same"
+
+        default_vlan_id = self.get(self.default_vlan_oid, ["SAI_VLAN_ATTR_VLAN_ID"]).value()
+        assert default_vlan_id == self.default_vlan_id, "Default VLAN ID is not the same"
+
+        default_vrf_oid = self.get(self.switch_oid, ["SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID"]).oid()
+        assert default_vrf_oid == self.default_vrf_oid, "Default VRF ID is not the same"
+
+        port_oids = self.get(self.switch_oid, ["SAI_SWITCH_ATTR_PORT_LIST"]).to_list()
+        assert port_oids == self.port_oids, "Port list is not the same"
+
+        dot1q_bp_oids = self.get(self.dot1q_br_oid, ["SAI_BRIDGE_ATTR_PORT_LIST"]).to_list()
+        assert dot1q_bp_oids == self.dot1q_bp_oids, "Bridge port list is not the same"
+
+
     def create_fdb(self, vlan_oid, mac, bp_oid, entry_type="SAI_FDB_ENTRY_TYPE_STATIC", action="SAI_PACKET_ACTION_FORWARD", do_assert=True):
         return self.create(
                    'SAI_OBJECT_TYPE_FDB_ENTRY:' + json.dumps(

--- a/docs/warm_reboot.md
+++ b/docs/warm_reboot.md
@@ -1,0 +1,55 @@
+# Warm reboot testing support
+
+Warm reboot lets the SAI process exit and restart while the ASIC dataplane keeps forwarding. SAI serializes its object database on shutdown and restores it on the next `sai_api_initialize()` — without reprogramming the ASIC or changing object IDs. This document describes what warm boot is and what was added for this feature.
+
+## Warm reboot flow in SAI
+
+### Phase 1 - before shutdown
+
+1. `SAI_WARM_BOOT_READ_FILE` and `SAI_WARM_BOOT_WRITE_FILE` should be set in `service_method_table_t`
+2. `SAI_SWITCH_ATTR_RESTART_WARM=true` is set by Host Adapter
+3. `SAI_SWITCH_ATTR_PRE_SHUTDOWN=true` is set by Host Adapter (optional)
+4. `SAI_SWITCH_ATTR_UNINIT_DATA_PLANE_ON_REMOVAL=false` is set for each switch by Host Adapter
+5. Host Adapter removes switches
+6. Host Adapter calls `sai_api_uninitialize`, SAI/SDK state should be dumped to `SAI_WARM_BOOT_WRITE_FILE`
+
+### Phase 2 - after shutdown
+
+1. `SAI_WARM_BOOT_READ_FILE`, `SAI_WARM_BOOT_WRITE_FILE` and `SAI_BOOT_TYPE=1` (0 - cold, 1 - warm, 2 - fast) should be set in `service_method_table_t`
+2. Host Adapter calls `sai_api_initialize`
+3. Host Adapter creates switch object during which SAI should restore the SAI/SDK state from before shutdown based on `SAI_WARM_BOOT_READ_FILE`. `create_switch` should return the same OID as before. If SAI supports creation of multiple switch objects, the OID should be based on `SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO`
+
+## Simplified warm reboot flow in SONiC
+
+This section focuses on SONiC warm reboot mainly from the `syncd` point of view. Check [SONiC_Warmboot.md](https://github.com/sonic-net/SONiC/blob/master/doc/warm-reboot/SONiC_Warmboot.md) for a better understanding of warm reboot in general. Warm reboot can be initiated using the [warm-reboot](https://github.com/sonic-net/sonic-utilities/blob/master/scripts/fast-reboot) script.
+
+### Phase 1 - before shutdown
+
+1. `syncd` sets default values for `SAI_WARM_BOOT_READ_FILE` and `SAI_WARM_BOOT_WRITE_FILE` before calling `sai_api_initialize` if they are not set in sai.profile
+2. `orchagent` disables FDB aging and FDB learning on all bridge ports.
+3. Pre-shutdown message is sent to `syncd` via Redis `RESTARTQUERY` channel, `syncd` sets `SAI_SWITCH_ATTR_RESTART_WARM=true` and `SAI_SWITCH_ATTR_PRE_SHUTDOWN=true`. `syncd` enters waiting mode in which it waits for shutdown request. `syncd` stores pre-shutdown state in `STATE_DB` `WARM_RESTART_TABLE|warm-shutdown` table
+4. Warm shutdown message is sent to `syncd`, `syncd` sets `SAI_SWITCH_ATTR_RESTART_WARM=true` and `SAI_SWITCH_ATTR_UNINIT_DATA_PLANE_ON_REMOVAL=false`. `syncd` stores pre-shutdown state in `STATE_DB` `WARM_RESTART_TABLE|warm-shutdown` table
+5. `syncd` removes switches
+6. `syncd` calls `sai_api_uninitialize` and exits
+
+### Phase 2 - after shutdown
+
+1. In `STATE_DB`, the `enable` field of `WARM_RESTART_ENABLE_TABLE|syncd` table (or `WARM_RESTART_ENABLE_TABLE|system` table) is set to true
+2. `syncd` is started
+3. `syncd` sets default values for `SAI_WARM_BOOT_READ_FILE` and `SAI_WARM_BOOT_WRITE_FILE` before calling `sai_api_initialize` if they are not set in sai.profile. `syncd` sets `SAI_BOOT_TYPE=1` by checking `WARM_RESTART_ENABLE_TABLE|syncd` table (or `WARM_RESTART_ENABLE_TABLE|system` table)
+4. `syncd` initializes SAI API and creates switches. For more details check `Syncd::performWarmRestart()` in [Syncd.cpp](https://github.com/sonic-net/sonic-sairedis/blob/master/syncd/Syncd.cpp)
+5. `orchagent` reconciles state from `APP_DB` and `STATE_DB` with `ASIC_DB`
+
+## How warm reboot is performed in SAI-Challenger
+
+Added `perform_warm_boot()` to the `Sai` class and `pre_shutdown()`, `warm_shutdown()`, and `verify_restore_after_warm_shutdown()` to the `SaiClient` class. Currently warm boot support is implemented only for the SAI Redis client; the SAI Thrift client throws an error on the newly added APIs. Check [sai_redis_client.py](../common/sai_client/sai_redis_client/sai_redis_client.py) for more details.
+
+Subclasses of the `Sai` base class may implement additional functionality for `perform_warm_boot()` along with additional validation, as it is done in [sai_npu.py](../common/sai_npu.py)
+
+## Example of testing warm reboot
+
+See [simple warm reboot test](../tests/test_warmboot.py)
+
+## Possible improvements
+
+* Add warm reboot support for SAI Thrift client

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -1,0 +1,113 @@
+import pytest
+from saichallenger.common.sai_data import SaiObjType
+from sai_client.sai_redis_client.sai_redis_client import SaiRedisClient
+
+from ptf.testutils import simple_tcp_packet, send_packet, verify_packets
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_all(testbed_instance, npu):
+    testbed = testbed_instance
+    if testbed is not None and len(testbed.npu) != 1:
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
+
+    if not isinstance(npu.sai_client, SaiRedisClient):
+        pytest.skip("Warm boot logic is not implemented for non-redis SAI client")
+
+@pytest.fixture(autouse=True)
+def on_prev_test_failure(prev_test_failed, npu):
+    if prev_test_failed:
+        npu.reset()
+
+def test_warmboot(npu, dataplane):
+    """
+    Description:
+    Check warm boot functionality
+
+    Test scenario:
+    1. Create a VLAN 10
+    2. Add two ports as untagged members to the VLAN
+    3. Setup static FDB entries for port 1 and port 2
+    4. Perform warm boot
+    4. Send a simple untagged packet on port 1 and verify packet on port 2
+    5. Clean up configuration
+    """
+    vlan_id = "10"
+    macs = ['00:11:11:11:11:11', '00:22:22:22:22:22']
+    max_port = 2
+    vlan_mbr_oids = []
+
+    vlan_oid = npu.create(SaiObjType.VLAN, ["SAI_VLAN_ATTR_VLAN_ID", vlan_id])
+
+    for idx in range(max_port):
+        npu.remove_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[idx])
+        vlan_mbr = npu.create_vlan_member(vlan_oid, npu.dot1q_bp_oids[idx], "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+        vlan_mbr_oids.append(vlan_mbr)
+        npu.set(npu.port_oids[idx], ["SAI_PORT_ATTR_PORT_VLAN_ID", vlan_id])
+        npu.create_fdb(vlan_oid, macs[idx], npu.dot1q_bp_oids[idx])
+
+    npu.perform_warm_reboot()
+
+    if npu.run_traffic:
+        pkt = simple_tcp_packet(eth_dst=macs[1],
+                                eth_src=macs[0],
+                                ip_dst='10.0.0.1',
+                                ip_id=101,
+                                ip_ttl=64)
+
+        send_packet(dataplane, 0, pkt)
+        verify_packets(dataplane, pkt, [1])
+
+    for idx in range(max_port):
+        npu.remove_fdb(vlan_oid, macs[idx])
+        npu.remove(vlan_mbr_oids[idx])
+        npu.create_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[idx], "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+        npu.set(npu.port_oids[idx], ["SAI_PORT_ATTR_PORT_VLAN_ID", npu.default_vlan_id])
+
+    npu.remove(vlan_oid)
+
+def test_two_warmboots(npu, dataplane):
+    """
+    Description:
+    Check two warm boot functionality
+
+    Test scenario:
+    1. Create a VLAN 10
+    2. Add two ports as untagged members to the VLAN
+    3. Setup static FDB entries for port 1 and port 2
+    4. Perform warm boot, verify forwarding, repeat once
+    5. Clean up configuration
+    """
+    vlan_id = "10"
+    macs = ['00:11:11:11:11:11', '00:22:22:22:22:22']
+    max_port = 2
+    vlan_mbr_oids = []
+
+    vlan_oid = npu.create(SaiObjType.VLAN, ["SAI_VLAN_ATTR_VLAN_ID", vlan_id])
+
+    for idx in range(max_port):
+        npu.remove_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[idx])
+        vlan_mbr = npu.create_vlan_member(vlan_oid, npu.dot1q_bp_oids[idx], "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+        vlan_mbr_oids.append(vlan_mbr)
+        npu.set(npu.port_oids[idx], ["SAI_PORT_ATTR_PORT_VLAN_ID", vlan_id])
+        npu.create_fdb(vlan_oid, macs[idx], npu.dot1q_bp_oids[idx])
+
+    pkt = simple_tcp_packet(eth_dst=macs[1],
+                            eth_src=macs[0],
+                            ip_dst='10.0.0.1',
+                            ip_id=101,
+                            ip_ttl=64)
+
+    for _ in range(2):
+        npu.perform_warm_reboot()
+        if npu.run_traffic:
+            send_packet(dataplane, 0, pkt)
+            verify_packets(dataplane, pkt, [1])
+
+    for idx in range(max_port):
+        npu.remove_fdb(vlan_oid, macs[idx])
+        npu.remove(vlan_mbr_oids[idx])
+        npu.create_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[idx], "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+        npu.set(npu.port_oids[idx], ["SAI_PORT_ATTR_PORT_VLAN_ID", npu.default_vlan_id])
+
+    npu.remove(vlan_oid)


### PR DESCRIPTION
## Summary

Add warm boot testing support by extending `Sai` and `SaiClient` API

## How to run new test
Build Docker image for SAI Redis client:
```sh
./build.sh -a trident2 -t saivs 
./run.sh -a trident2 -t saivs
```
Run test:
```sh
./exec.sh -t saivs pytest --testbed=saivs_standalone -v test_warm_reboot.py
```

## Test results
```sh
===================================================================== test session starts ======================================================================
platform linux -- Python 3.11.2, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.11.2', 'Platform': 'Linux-6.17.0-35-generic-x86_64-with-glibc2.36', 'Packages': {'pytest': '9.1.1', 'pluggy': '1.6.0'}, 'Plugins': {'metadata': '3.1.1', 'html': '4.2.0', 'dependency': '0.6.1'}}
rootdir: /sai-challenger/tests
configfile: pytest.ini
plugins: metadata-3.1.1, html-4.2.0, dependency-0.6.1
collected 2 items                                                                                                                                              

test_warm_reboot.py::test_warmboot PASSED                                                                                                                [ 50%]
test_warm_reboot.py::test_two_warmboots PASSED                                                                                                           [100%]

====================================================================== 2 passed in 34.51s ======================================================================
```