### PR TITLE
Clean up procedure for ptf based tests

### DIFF
--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -556,7 +556,6 @@ class TestFdbLearn:
         request.cls.vlan10_member_lag2 = npu.create_vlan_member(
             request.cls.vlan_oid, request.cls.lag2_bp, "SAI_VLAN_TAGGING_MODE_TAGGED"
         )
-        topo.def_vlan_member_list.append(request.cls.vlan10_member_lag2)
         request.cls.src_ports = [
             request.cls.dev_port0,
             request.cls.dev_port1,
@@ -574,6 +573,7 @@ class TestFdbLearn:
             npu.switch_oid,
             ["SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid, "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
         )
+        npu.remove(request.cls.vlan10_member_lag2)
         npu._topo_initialized = False
 
     def test_dynamic_mac_learn(self, npu, dataplane):

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -1,5 +1,7 @@
 import json
 import time
+import logging
+logger = logging.getLogger(__name__)
 
 import pytest
 
@@ -23,16 +25,64 @@ def skip_all(testbed_instance):
         pytest.skip('invalid for "{}" testbed'.format(testbed.name))
 
 
-@pytest.fixture(autouse=True)
-def on_prev_test_failure(prev_test_failed, npu):
-    if prev_test_failed:
-        npu.reset()
+class TopologyManager:
+    """
+    Manages the SAI PTF topology lifecycle with caching and safe recovery capabilities.
+
+    Execution model:
+    1. A module-scoped fixture instantiates one manager per test module.
+    2. Test classes initialize their specific configuration lazily via a setup 
+       fixture using a class-level initialization flag (`_cls_initialized`).
+    3. `get_topology()` provides access to the active topology, reusing the cached 
+       instance across consecutive successful tests.
+    4. If a test fails (`prev_test_failed`), `reset()` closes the active context, 
+       invalidates the cache, and executes a hard reset on the NPU to guarantee 
+       a clean state for subsequent tests.
+    """
+
+    def __init__(self, npu):
+        """Initializes the manager with the target NPU."""
+        self.npu = npu
+        self._ctx = None
+        self.topo = None
+
+    def get_topology(self):
+        """
+        Retrieves the active topology.
+        Initializes a new `sai_ptf_topology.config()` context if none exists in cache.
+        """
+        if self.topo is None:
+            self._ctx = saichallenger.topologies.sai_ptf_topology.config(self.npu)
+            self.topo = self._ctx.__enter__()
+        return self.topo
+
+    def reset(self):
+        """
+        Tears down the active topology context, invalidates the cache (`topo = None`),
+        and executes a hard reset on the NPU.
+        """
+        if self._ctx is not None:
+            try:
+                self._ctx.__exit__(None, None, None)
+            except Exception as e:
+                logger.warning(f"Error closing topology context during reset: {e}")
+            finally:
+                self._ctx = None
+                self.topo = None
+
+        self.npu.reset()
 
 
 @pytest.fixture(scope="module")
-def sai_ptf_topology(npu):
-    with saichallenger.topologies.sai_ptf_topology.config(npu) as topo:
-        yield topo
+def sai_ptf_topology_manager(npu):
+    """
+    Persists the topology cache across successful tests within the module
+    and executes a final `manager.reset()` upon module completion to ensure 
+    the NPU is left in a clean state.
+    """
+    manager = TopologyManager(npu)
+    yield manager
+    manager.reset()
 
 
 def _fdb_entry_key(npu, vlan_oid, mac):
@@ -79,32 +129,51 @@ class TestFdbStaticMac:
     """
     Topology for FdbStaticMacTest: provides VLAN 10, lag1, bridge ports and PVIDs.
     """
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
+        """
+        Invoked before EACH test to check topology state, but applies full 
+        class configuration ONLY on the first run or after a test failure.
+        """
+        if prev_test_failed:
+            sai_ptf_topology_manager.reset()
+            request.cls._cls_initialized = False
+
+        if not getattr(request.cls, "_cls_initialized", False):
+            topo = sai_ptf_topology_manager.get_topology()
+
+            request.cls.topo = topo
+            request.cls.vlan_oid = topo.vlan10
+            request.cls.vlan_id_int = 10
+            request.cls.lag_bp_oid = topo.lag1_bp
+            request.cls.dev_port0 = 0
+            request.cls.dev_port1 = 1
+            request.cls.lag_dev_ports = [4, 5, 6]
+            request.cls.port0_bp = topo.port0_bp
+            request.cls.port1_bp = topo.port1_bp
+            request.cls.macs = []
+
+            for i in range(1, 4):
+                request.cls.macs.append("00:%02d:%02d:%02d:%02d:%02d" % (i, i, i, i, i))
+            request.cls.dst_port_groups = [
+                [request.cls.dev_port0],
+                [request.cls.dev_port1],
+                request.cls.lag_dev_ports,
+            ]
+
+            npu.create_fdb(request.cls.vlan_oid, request.cls.macs[0], request.cls.port0_bp)
+            npu.create_fdb(request.cls.vlan_oid, request.cls.macs[1], request.cls.port1_bp)
+            npu.create_fdb(request.cls.vlan_oid, request.cls.macs[2], request.cls.lag_bp_oid)
+            request.cls._cls_initialized = True
+
     @pytest.fixture(scope="class", autouse=True)
-    def setup_teardown(self, request, npu, sai_ptf_topology):
-        topo = sai_ptf_topology
-        request.cls.vlan_oid = topo.vlan10
-        request.cls.vlan_id_int = 10
-        request.cls.lag_bp_oid = topo.lag1_bp
-        request.cls.dev_port0 = 0
-        request.cls.dev_port1 = 1
-        request.cls.lag_dev_ports = [4, 5, 6]
-        request.cls.port0_bp = topo.port0_bp
-        request.cls.port1_bp = topo.port1_bp
-        request.cls.macs = []
-
-        for i in range(1, 4):
-            request.cls.macs.append("00:%02d:%02d:%02d:%02d:%02d" % (i, i, i, i, i))
-        request.cls.dst_port_groups = [
-            [request.cls.dev_port0],
-            [request.cls.dev_port1],
-            request.cls.lag_dev_ports,
-        ]
-
-        npu.create_fdb(request.cls.vlan_oid, request.cls.macs[0], request.cls.port0_bp)
-        npu.create_fdb(request.cls.vlan_oid, request.cls.macs[1], request.cls.port1_bp)
-        npu.create_fdb(request.cls.vlan_oid, request.cls.macs[2], request.cls.lag_bp_oid)
-
+    def teardown(self, request, npu):
+        """
+        Teardown fixture: cleans up resources AFTER test execution.
+        Starts with `yield`, waits for the test to complete, and flushes FDB entries.
+        """
         yield
+        request.cls._cls_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
@@ -172,21 +241,37 @@ class TestFdbAttribute:
     """
     Topology for FdbAttributeTest: provides VLAN 10, bridge port and test MAC address.
     """
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
+        if prev_test_failed:
+            sai_ptf_topology_manager.reset()
+
+        if not getattr(request.cls, "_cls_initialized", False):
+            topo = sai_ptf_topology_manager.get_topology()
+
+            request.cls.topo = topo
+
+            request.cls.vlan_oid = topo.vlan10
+            request.cls.mac = "00:11:22:33:44:55"
+            request.cls.port0_bp = topo.port0_bp
+
+            npu.create_fdb(
+                request.cls.vlan_oid, request.cls.mac, request.cls.port0_bp
+            )
+            request.cls._cls_initialized = True
+
     @pytest.fixture(scope="class", autouse=True)
-    def setup_teardown(self, request, npu, sai_ptf_topology):
-        topo = sai_ptf_topology
-        request.cls.vlan_oid = topo.vlan10
-        request.cls.mac = "00:11:22:33:44:55"
-        request.cls.port0_bp = topo.port0_bp
-
-        npu.create_fdb(request.cls.vlan_oid, request.cls.mac, request.cls.port0_bp)
-
+    def teardown(self, request, npu):
         yield
+        request.cls._cls_initialized = False
+
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
-                "SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid,
-                "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
+                "SAI_FDB_FLUSH_ATTR_BV_ID",
+                request.cls.vlan_oid,
+                "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE",
+                "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
             ],
         )
 
@@ -220,24 +305,35 @@ class TestFdbNoLearn:
     """
     Topology for FdbNoLearnTest: VLAN 10 with port0/port1 and lag1.
     """
-    @pytest.fixture(scope="class", autouse=True)
-    def setup_teardown(self, request, npu, sai_ptf_topology):
-        topo = sai_ptf_topology
-        request.cls._topo = topo
-        request.cls.vlan_oid = topo.vlan10
-        request.cls.vlan_id_int = 10
-        request.cls.port0_bp = topo.port0_bp
-        request.cls.port1_bp = topo.port1_bp
-        request.cls.lag1_bp = topo.lag1_bp
-        request.cls.vlan10_member0 = topo.vlan10_member0
-        request.cls.dev_port0 = 0
-        request.cls.dev_port1 = 1
-        request.cls.lag_ports = [4, 5, 6]
-        request.cls.port10 = topo.port10
-        request.cls.src_mac = "00:11:11:11:11:11"
-        request.cls.dst_mac = "00:22:22:22:22:22"
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, request, sai_ptf_topology_manager, prev_test_failed):
+        if prev_test_failed:
+            sai_ptf_topology_manager.reset()
+            request.cls._cls_initialized = False
 
+        if not getattr(request.cls, "_cls_initialized", False):
+            topo = sai_ptf_topology_manager.get_topology()
+
+            request.cls._topo = topo
+            request.cls.vlan_oid = topo.vlan10
+            request.cls.vlan_id_int = 10
+            request.cls.port0_bp = topo.port0_bp
+            request.cls.port1_bp = topo.port1_bp
+            request.cls.lag1_bp = topo.lag1_bp
+            request.cls.vlan10_member0 = topo.vlan10_member0
+            request.cls.dev_port0 = 0
+            request.cls.dev_port1 = 1
+            request.cls.lag_ports = [4, 5, 6]
+            request.cls.port10 = topo.port10
+            request.cls.src_mac = "00:11:11:11:11:11"
+            request.cls.dst_mac = "00:22:22:22:22:22"
+            request.cls._cls_initialized = True
+
+    @pytest.fixture(scope="class", autouse=True)
+    def teardown(self, request, npu):
         yield
+        request.cls._cls_initialized = False
+        
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
@@ -496,41 +592,51 @@ class TestFdbLearn:
     """
     Topology for FdbLearnTest: VLAN 10 ports + lag1 and temporarily added lag2 (tagged).
     """
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
+        if prev_test_failed:
+            sai_ptf_topology_manager.reset()
+            request.cls._cls_initialized = False
+    
+        if not getattr(request.cls, "_cls_initialized", False):
+            topo = sai_ptf_topology_manager.get_topology()
+            request.cls._topo = topo
+            request.cls.vlan_oid = topo.vlan10
+            request.cls.vlan_id_int = 10
+            request.cls.dev_port0 = 0
+            request.cls.dev_port1 = 1
+            request.cls.utg_lag_ports = [4, 5, 6]
+            request.cls.tg_lag_ports = [7, 8, 9]
+            request.cls.dst_port_groups = [
+                [request.cls.dev_port0],
+                [request.cls.dev_port1],
+                request.cls.utg_lag_ports,
+                request.cls.tg_lag_ports,
+            ]
+            request.cls.port0_bp = topo.port0_bp
+            request.cls.port1_bp = topo.port1_bp
+            request.cls.lag1_bp = topo.lag1_bp
+            request.cls.lag2_bp = topo.lag2_bp
+            request.cls.lag1 = topo.lag1
+            request.cls.vlan10_member1 = topo.vlan10_member1
+            request.cls.lag1_member5 = topo.lag1_member5
+            request.cls.vlan10_member_lag2 = npu.create_vlan_member(
+                request.cls.vlan_oid, request.cls.lag2_bp, "SAI_VLAN_TAGGING_MODE_TAGGED"
+            )
+            request.cls.src_ports = [
+                request.cls.dev_port0,
+                request.cls.dev_port1,
+                4, 5, 6, 7, 8, 9,
+            ]
+            request.cls.macs = [
+                "00:%02d:%02d:%02d:%02d:%02d" % (i, i, i, i, i) for i in range(1, len(request.cls.src_ports))
+            ]
+            request.cls._cls_initialized = True
+
     @pytest.fixture(scope="class", autouse=True)
-    def setup_teardown(self, request, npu, sai_ptf_topology):
-        topo = sai_ptf_topology
-        request.cls._topo = topo
-        request.cls.vlan_oid = topo.vlan10
-        request.cls.vlan_id_int = 10
-        request.cls.dev_port0 = 0
-        request.cls.dev_port1 = 1
-        request.cls.utg_lag_ports = [4, 5, 6]
-        request.cls.tg_lag_ports = [7, 8, 9]
-        request.cls.dst_port_groups = [
-            [request.cls.dev_port0],
-            [request.cls.dev_port1],
-            request.cls.utg_lag_ports,
-            request.cls.tg_lag_ports,
-        ]
-        request.cls.port0_bp = topo.port0_bp
-        request.cls.port1_bp = topo.port1_bp
-        request.cls.lag1_bp = topo.lag1_bp
-        request.cls.lag2_bp = topo.lag2_bp
-        request.cls.lag1 = topo.lag1
-        request.cls.vlan10_member1 = topo.vlan10_member1
-        request.cls.lag1_member5 = topo.lag1_member5
-        request.cls.vlan10_member_lag2 = npu.create_vlan_member(
-            request.cls.vlan_oid, request.cls.lag2_bp, "SAI_VLAN_TAGGING_MODE_TAGGED"
-        )
-        request.cls.src_ports = [
-            request.cls.dev_port0,
-            request.cls.dev_port1,
-            4, 5, 6, 7, 8, 9,
-        ]
-        request.cls.macs = [
-            "00:%02d:%02d:%02d:%02d:%02d" % (i, i, i, i, i) for i in range(1, len(request.cls.src_ports))
-        ]
+    def teardown(self, request, npu):
         yield
+        request.cls._cls_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             ["SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid, "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
@@ -894,88 +1000,104 @@ class TestFdbMacMove:
     Topology for FdbMacMoveTest: VLAN 10 with port1 untagged, extra access port24,
     static chck_mac on port24_bp, and lag10 (ports 25–27) in VLAN 10.
     """
-    @pytest.fixture(scope="class", autouse=True)
-    def setup_teardown(self, request, npu, sai_ptf_topology):
-        topo = sai_ptf_topology
-        if len(npu.port_oids) < 28:
-            pytest.skip("FdbMacMoveTest requires physical port indices 0–27 (28 ports)")
-        request.cls.vlan_oid = topo.vlan10
-        request.cls.port0_bp = topo.port0_bp
-        request.cls.port1_bp = topo.port1_bp
-        request.cls.lag1_bp = topo.lag1_bp
-        request.cls.port0 = topo.port0
-        request.cls.port1 = topo.port1
-        request.cls.lag1 = topo.lag1
-        request.cls.dev_port0 = 0
-        request.cls.dev_port1 = 1
-        request.cls.dev_port5 = 5
-        request.cls.dev_port24 = 24
-        request.cls.dev_port27 = 27
-        request.cls.lag1_ports = [4, 5, 6]
-        request.cls.lag3_ports = [25, 26, 27]
-        request.cls.moving_mac = "00:11:22:33:44:55"
-        request.cls.chck_mac = "00:11:11:11:11:11"
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
+        if prev_test_failed:
+            sai_ptf_topology_manager.reset()
+            request.cls._cls_initialized = False
 
-        old_vlan10_member1 = topo.vlan10_member1
-        npu.remove(old_vlan10_member1)
-        vlan10_member1_ut = npu.create_vlan_member(
-            request.cls.vlan_oid, topo.port1_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
-        )
-        npu.set(topo.port1, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
+        if not getattr(request.cls, "_cls_initialized", False):
+            if len(npu.port_oids) < 28:
+                            pytest.skip("FdbMacMoveTest requires physical port indices 0–27 (28 ports)")
+            
+            topo = sai_ptf_topology_manager.get_topology()
+            request.cls.topo = topo
+            
+            request.cls.vlan_oid = topo.vlan10
+            request.cls.port0_bp = topo.port0_bp
+            request.cls.port1_bp = topo.port1_bp
+            request.cls.lag1_bp = topo.lag1_bp
+            request.cls.port0 = topo.port0
+            request.cls.port1 = topo.port1
+            request.cls.lag1 = topo.lag1
+            request.cls.dev_port0 = 0
+            request.cls.dev_port1 = 1
+            request.cls.dev_port5 = 5
+            request.cls.dev_port24 = 24
+            request.cls.dev_port27 = 27
+            request.cls.lag1_ports = [4, 5, 6]
+            request.cls.lag3_ports = [25, 26, 27]
+            request.cls.moving_mac = "00:11:22:33:44:55"
+            request.cls.chck_mac = "00:11:11:11:11:11"
 
-        port24_oid = npu.port_oids[24]
-        port24_bp = npu.create(
-            SaiObjType.BRIDGE_PORT,
-            [
-                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
-                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-            ],
-        )
-        vlan10_member3 = npu.create_vlan_member(
-            request.cls.vlan_oid, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
-        )
-        npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
-
-        lag10 = npu.create(SaiObjType.LAG, [])
-        lag10_bp = npu.create(
-            SaiObjType.BRIDGE_PORT,
-            [
-                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                "SAI_BRIDGE_PORT_ATTR_PORT_ID", lag10,
-                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-            ],
-        )
-        lag10_members = []
-        for pidx in (25, 26, 27):
-            lag10_members.append(
-                npu.create(
-                    SaiObjType.LAG_MEMBER,
-                    [
-                        "SAI_LAG_MEMBER_ATTR_LAG_ID", lag10,
-                        "SAI_LAG_MEMBER_ATTR_PORT_ID", npu.port_oids[pidx],
-                    ],
-                )
+            old_vlan10_member1 = topo.vlan10_member1
+            npu.remove(old_vlan10_member1)
+            vlan10_member1_ut = npu.create_vlan_member(
+                request.cls.vlan_oid, topo.port1_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
             )
-        vlan10_member4 = npu.create_vlan_member(
-            request.cls.vlan_oid, lag10_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
-        )
-        npu.set(lag10, ["SAI_LAG_ATTR_PORT_VLAN_ID", "10"])
+            npu.set(topo.port1, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
 
-        request.cls.lag10_bp = lag10_bp
-        request.cls.port24_bp = port24_bp
-        npu.create_fdb(request.cls.vlan_oid, request.cls.chck_mac, port24_bp)
+            port24_oid = npu.port_oids[24]
+            port24_bp = npu.create(
+                SaiObjType.BRIDGE_PORT,
+                [
+                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
+                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+                ],
+            )
+            vlan10_member3 = npu.create_vlan_member(
+                request.cls.vlan_oid, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
+            )
+            npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
 
-        request.cls._topo = topo
-        request.cls._vlan10_member1_ut = vlan10_member1_ut
-        request.cls._port24_oid = port24_oid
-        request.cls._vlan10_member3 = vlan10_member3
-        request.cls._lag10 = lag10
-        request.cls._lag10_bp = lag10_bp
-        request.cls._lag10_members = lag10_members
-        request.cls._vlan10_member4 = vlan10_member4
+            lag10 = npu.create(SaiObjType.LAG, [])
+            lag10_bp = npu.create(
+                SaiObjType.BRIDGE_PORT,
+                [
+                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", lag10,
+                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+                ],
+            )
+            lag10_members = []
+            for pidx in (25, 26, 27):
+                lag10_members.append(
+                    npu.create(
+                        SaiObjType.LAG_MEMBER,
+                        [
+                            "SAI_LAG_MEMBER_ATTR_LAG_ID", lag10,
+                            "SAI_LAG_MEMBER_ATTR_PORT_ID", npu.port_oids[pidx],
+                        ],
+                    )
+                )
+            vlan10_member4 = npu.create_vlan_member(
+                request.cls.vlan_oid, lag10_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
+            )
+            npu.set(lag10, ["SAI_LAG_ATTR_PORT_VLAN_ID", "10"])
 
+            request.cls.lag10_bp = lag10_bp
+            request.cls.port24_bp = port24_bp
+            npu.create_fdb(request.cls.vlan_oid, request.cls.chck_mac, port24_bp)
+
+            request.cls._topo = topo
+            request.cls._vlan10_member1_ut = vlan10_member1_ut
+            request.cls._port24_oid = port24_oid
+            request.cls._vlan10_member3 = vlan10_member3
+            request.cls._lag10 = lag10
+            request.cls._lag10_bp = lag10_bp
+            request.cls._lag10_members = lag10_members
+            request.cls._vlan10_member4 = vlan10_member4
+            request.cls._cls_initialized = True
+            
+
+    @pytest.fixture(scope="class", autouse=True)
+    def teardown(self, request, npu):
         yield
+        request.cls._cls_initialized = False
+        topo = getattr(request.cls, "_topo", None)
+        if topo is None:
+            return
 
         npu.flush_fdb_entries(
             npu.switch_oid,
@@ -1105,12 +1227,26 @@ class TestFdbFlush:
     Topology for FdbFlushTest: port1/port3/lag2 retagged like PTF, trunk stub on port24, dual flood+forward checks.
     """
 
-    @pytest.fixture(scope="class", autouse=True)
-    def setup_teardown(self, request, npu, sai_ptf_topology):
-        topo = sai_ptf_topology
-        if len(npu.port_oids) <= 24:
-            pytest.skip("FdbFlushTest requires physical port index 24 (25 ports)")
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
+        """Setup topology and test state before execution."""
+        if prev_test_failed:
+            sai_ptf_topology_manager.reset()
+            request.cls._cls_initialized = False
 
+        if not getattr(request.cls, "_cls_initialized", False):
+            if len(npu.port_oids) <= 24:
+                pytest.skip("FdbFlushTest requires physical port index 24 (25 ports)")
+
+            topo = sai_ptf_topology_manager.get_topology()
+
+            _m = npu.get_vlan_member(topo.vlan10, topo.port1_bp)
+            if _m is not None:
+                npu.remove(_m)
+            vlan10_member1_ut = npu.create_vlan_member(
+                topo.vlan10, topo.port1_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
+            )
+            npu.set(topo.port1, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
         vlan10_oid = None
         vlan20_oid = None
         port24_bp = None
@@ -1151,6 +1287,7 @@ class TestFdbFlush:
                 "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
             ],
         )
+
 
         vlan10_oid = topo.vlan10
         vlan20_oid = topo.vlan20
@@ -1194,7 +1331,10 @@ class TestFdbFlush:
         request.cls._vlan10_member1_ut = vlan10_member1_ut
         request.cls._vlan20_member1_ut = vlan20_member1_ut
         request.cls._vlan20_member2_ut = vlan20_member2_ut
+        request.cls._cls_initialized = True
 
+    @pytest.fixture(scope="class", autouse=True)
+    def teardown(self, request, npu):
         yield
         # SAI-oriented teardown: flush FDB → remove VLAN members (incl. test trunk) →
         # remove objects we created (bridge port). Topology VLANs/LAGs are not removed here.
@@ -2317,39 +2457,54 @@ class TestFdbAge:
     Topology for FdbAgeTest: global FDB aging time, extra VLAN10 member on port24,
     static vrf_mac on port24_bp for routed verification traffic toward CPU path.
     """
+    @pytest.fixture(scope="function", autouse=True)
+
+    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
+
+        if prev_test_failed:
+            sai_ptf_topology_manager.reset()
+            request.cls._cls_initialized = False
+            
+
+        if not getattr(request.cls, "_cls_initialized", False):
+            if len(npu.port_oids) < 25:
+                    pytest.skip("FdbAgeTest requires physical port index 24 (25 ports)")
+
+            topo = sai_ptf_topology_manager.get_topology()
+
+            request.cls.topo = topo
+            request.cls.vlan_oid = topo.vlan10
+            request.cls.vlan_id_int = 10
+            request.cls.age_time = 10
+            request.cls.vrf_mac = "00:12:34:56:78:90"
+            request.cls.vrf_port_dev = 24
+
+            npu.set(npu.switch_oid, ["SAI_SWITCH_ATTR_FDB_AGING_TIME", str(request.cls.age_time)])
+
+            port24_oid = npu.port_oids[24]
+            port24_bp = npu.create(
+                SaiObjType.BRIDGE_PORT,
+                [
+                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
+                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+                ],
+            )
+            vlan10_member3 = npu.create_vlan_member(
+                request.cls.vlan_oid, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
+            )
+            npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", str(request.cls.vlan_id_int)])
+            npu.create_fdb(request.cls.vlan_oid, request.cls.vrf_mac, port24_bp)
+
+            request.cls._port24_oid = port24_oid
+            request.cls._port24_bp = port24_bp
+            request.cls._vlan10_member3 = vlan10_member3
+            request.cls._cls_initialized = True
+
     @pytest.fixture(scope="class", autouse=True)
-    def setup_teardown(self, request, npu, sai_ptf_topology):
-        topo = sai_ptf_topology
-        if len(npu.port_oids) < 25:
-            pytest.skip("FdbAgeTest requires physical port index 24 (25 ports)")
-        request.cls.vlan_oid = topo.vlan10
-        request.cls.vlan_id_int = 10
-        request.cls.age_time = 10
-        request.cls.vrf_mac = "00:12:34:56:78:90"
-        request.cls.vrf_port_dev = 24
-
-        npu.set(npu.switch_oid, ["SAI_SWITCH_ATTR_FDB_AGING_TIME", str(request.cls.age_time)])
-
-        port24_oid = npu.port_oids[24]
-        port24_bp = npu.create(
-            SaiObjType.BRIDGE_PORT,
-            [
-                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
-                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-            ],
-        )
-        vlan10_member3 = npu.create_vlan_member(
-            request.cls.vlan_oid, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
-        )
-        npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", str(request.cls.vlan_id_int)])
-        npu.create_fdb(request.cls.vlan_oid, request.cls.vrf_mac, port24_bp)
-
-        request.cls._port24_oid = port24_oid
-        request.cls._port24_bp = port24_bp
-        request.cls._vlan10_member3 = vlan10_member3
-
+    def teardown(self, request, npu):
         yield
+        request.cls._cls_initialized = False
 
         npu.flush_fdb_entries(
             npu.switch_oid,
@@ -2571,101 +2726,113 @@ class TestFdbMiss:
     """
     Topology for FdbMissTest: VLAN 100 on ports 24–26, hostif trap group (queue 4) with ARP + LLDP traps.
     """
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
+  
+        if prev_test_failed:
+            sai_ptf_topology_manager.reset()
+            request.cls._cls_initialized = False
 
+        if not getattr(request.cls, "_cls_initialized", False):
+            if len(npu.port_oids) <= 26:
+                pytest.skip("FdbMissTest requires physical port indices 24–26 (27 ports)")
+
+            topo =  sai_ptf_topology_manager.get_topology()
+            port24_oid = npu.port_oids[24]
+            port25_oid = npu.port_oids[25]
+            port26_oid = npu.port_oids[26]
+
+            port24_bp = npu.create(
+                SaiObjType.BRIDGE_PORT,
+                [
+                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
+                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+                ],
+            )
+            port25_bp = npu.create(
+                SaiObjType.BRIDGE_PORT,
+                [
+                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", port25_oid,
+                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+                ],
+            )
+            port26_bp = npu.create(
+                SaiObjType.BRIDGE_PORT,
+                [
+                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", port26_oid,
+                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+                ],
+            )
+
+            vlan100 = npu.create(SaiObjType.VLAN, ["SAI_VLAN_ATTR_VLAN_ID", "100"])
+            vm0 = npu.create_vlan_member(vlan100, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+            vm1 = npu.create_vlan_member(vlan100, port25_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+            vm2 = npu.create_vlan_member(vlan100, port26_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+
+            npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
+            npu.set(port25_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
+            npu.set(port26_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
+
+            trap_group = npu.create(
+                "SAI_OBJECT_TYPE_HOSTIF_TRAP_GROUP",
+                ["SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE", "4"],
+            )
+            arp_trap = npu.create(
+                "SAI_OBJECT_TYPE_HOSTIF_TRAP",
+                [
+                    "SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE", "SAI_HOSTIF_TRAP_TYPE_ARP_REQUEST",
+                    "SAI_HOSTIF_TRAP_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_TRAP",
+                    "SAI_HOSTIF_TRAP_ATTR_TRAP_GROUP", trap_group,
+                ],
+            )
+            lldp_trap = npu.create(
+                "SAI_OBJECT_TYPE_HOSTIF_TRAP",
+                [
+                    "SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE", "SAI_HOSTIF_TRAP_TYPE_LLDP",
+                    "SAI_HOSTIF_TRAP_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_TRAP",
+                    "SAI_HOSTIF_TRAP_ATTR_TRAP_GROUP", trap_group,
+                ],
+            )
+
+            request.cls.topo = topo
+            request.cls.vlan_oid = vlan100
+            request.cls.send_port = 24
+            request.cls.flood_ports = [25, 26]
+            request.cls.src_mac = "00:11:11:11:11:11"
+            request.cls.dst_mac = "00:22:22:22:22:22"
+            request.cls.mcast_mac = "01:00:5e:11:22:33"
+            request.cls.bcast_mac = "ff:ff:ff:ff:ff:ff"
+            request.cls.lldp_mac = "01:80:c2:00:00:0e"
+            request.cls.ucast_pkt = simple_udp_packet(eth_dst=request.cls.dst_mac, eth_src=request.cls.src_mac)
+            request.cls.mcast_pkt = simple_udp_packet(eth_dst=request.cls.mcast_mac, eth_src=request.cls.src_mac)
+            request.cls.bcast_pkt = simple_udp_packet(eth_dst=request.cls.bcast_mac, eth_src=request.cls.src_mac)
+            request.cls.arp_pkt = simple_arp_packet(arp_op=1, pktlen=100)
+            request.cls.lldp_pkt = simple_eth_packet(
+                eth_dst=request.cls.lldp_mac, eth_src=request.cls.src_mac, pktlen=60, eth_type=0x88cc
+            )
+
+            request.cls._port24_oid = port24_oid
+            request.cls._port25_oid = port25_oid
+            request.cls._port26_oid = port26_oid
+            request.cls._port24_bp = port24_bp
+            request.cls._port25_bp = port25_bp
+            request.cls._port26_bp = port26_bp
+            request.cls._vlan100 = vlan100
+            request.cls._vm0 = vm0
+            request.cls._vm1 = vm1
+            request.cls._vm2 = vm2
+            request.cls._trap_group = trap_group
+            request.cls._arp_trap = arp_trap
+            request.cls._lldp_trap = lldp_trap
+            request.cls._cls_initialized = True
+            
     @pytest.fixture(scope="class", autouse=True)
-    def setup_teardown(self, request, npu, sai_ptf_topology):
-        if len(npu.port_oids) <= 26:
-            pytest.skip("FdbMissTest requires physical port indices 24–26 (27 ports)")
-        port24_oid = npu.port_oids[24]
-        port25_oid = npu.port_oids[25]
-        port26_oid = npu.port_oids[26]
-
-        port24_bp = npu.create(
-            SaiObjType.BRIDGE_PORT,
-            [
-                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
-                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-            ],
-        )
-        port25_bp = npu.create(
-            SaiObjType.BRIDGE_PORT,
-            [
-                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                "SAI_BRIDGE_PORT_ATTR_PORT_ID", port25_oid,
-                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-            ],
-        )
-        port26_bp = npu.create(
-            SaiObjType.BRIDGE_PORT,
-            [
-                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                "SAI_BRIDGE_PORT_ATTR_PORT_ID", port26_oid,
-                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-            ],
-        )
-
-        vlan100 = npu.create(SaiObjType.VLAN, ["SAI_VLAN_ATTR_VLAN_ID", "100"])
-        vm0 = npu.create_vlan_member(vlan100, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
-        vm1 = npu.create_vlan_member(vlan100, port25_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
-        vm2 = npu.create_vlan_member(vlan100, port26_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
-
-        npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
-        npu.set(port25_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
-        npu.set(port26_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
-
-        trap_group = npu.create(
-            "SAI_OBJECT_TYPE_HOSTIF_TRAP_GROUP",
-            ["SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE", "4"],
-        )
-        arp_trap = npu.create(
-            "SAI_OBJECT_TYPE_HOSTIF_TRAP",
-            [
-                "SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE", "SAI_HOSTIF_TRAP_TYPE_ARP_REQUEST",
-                "SAI_HOSTIF_TRAP_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_TRAP",
-                "SAI_HOSTIF_TRAP_ATTR_TRAP_GROUP", trap_group,
-            ],
-        )
-        lldp_trap = npu.create(
-            "SAI_OBJECT_TYPE_HOSTIF_TRAP",
-            [
-                "SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE", "SAI_HOSTIF_TRAP_TYPE_LLDP",
-                "SAI_HOSTIF_TRAP_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_TRAP",
-                "SAI_HOSTIF_TRAP_ATTR_TRAP_GROUP", trap_group,
-            ],
-        )
-
-        request.cls.vlan_oid = vlan100
-        request.cls.send_port = 24
-        request.cls.flood_ports = [25, 26]
-        request.cls.src_mac = "00:11:11:11:11:11"
-        request.cls.dst_mac = "00:22:22:22:22:22"
-        request.cls.mcast_mac = "01:00:5e:11:22:33"
-        request.cls.bcast_mac = "ff:ff:ff:ff:ff:ff"
-        request.cls.lldp_mac = "01:80:c2:00:00:0e"
-        request.cls.ucast_pkt = simple_udp_packet(eth_dst=request.cls.dst_mac, eth_src=request.cls.src_mac)
-        request.cls.mcast_pkt = simple_udp_packet(eth_dst=request.cls.mcast_mac, eth_src=request.cls.src_mac)
-        request.cls.bcast_pkt = simple_udp_packet(eth_dst=request.cls.bcast_mac, eth_src=request.cls.src_mac)
-        request.cls.arp_pkt = simple_arp_packet(arp_op=1, pktlen=100)
-        request.cls.lldp_pkt = simple_eth_packet(
-            eth_dst=request.cls.lldp_mac, eth_src=request.cls.src_mac, pktlen=60, eth_type=0x88cc
-        )
-
-        request.cls._port24_oid = port24_oid
-        request.cls._port25_oid = port25_oid
-        request.cls._port26_oid = port26_oid
-        request.cls._port24_bp = port24_bp
-        request.cls._port25_bp = port25_bp
-        request.cls._port26_bp = port26_bp
-        request.cls._vlan100 = vlan100
-        request.cls._vm0 = vm0
-        request.cls._vm1 = vm1
-        request.cls._vm2 = vm2
-        request.cls._trap_group = trap_group
-        request.cls._arp_trap = arp_trap
-        request.cls._lldp_trap = lldp_trap
-
+    def teardown(self, request, npu):
         yield
+        request.cls._cls_initialized = False
 
         npu.flush_fdb_entries(
             npu.switch_oid,
@@ -2998,16 +3165,28 @@ class TestFdbEvent:
     """
     Topology for FdbEventTest: validate FDB attributes on learn/age/move/flush/delete.
     """
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self, request, sai_ptf_topology_manager, prev_test_failed):
+        if prev_test_failed:
+            sai_ptf_topology_manager.reset()
+            request.cls._cls_initialized = False
+
+        if not getattr(request.cls, "_cls_initialized", False):
+            topo = sai_ptf_topology_manager.get_topology()
+        
+            request.cls.topo = topo
+            request.cls.vlan_oid = topo.vlan10
+            request.cls.port0_bp = topo.port0_bp
+            request.cls.lag1_bp = topo.lag1_bp
+            request.cls.vlan_id_int = 10
+            request.cls.src_mac = "00:11:11:11:11:11"
+            request.cls.dst_mac = "00:22:22:22:22:22"
+            request.cls._cls_initialized = True
+
     @pytest.fixture(scope="class", autouse=True)
-    def setup_teardown(self, request, npu, sai_ptf_topology):
-        topo = sai_ptf_topology
-        request.cls.vlan_oid = topo.vlan10
-        request.cls.port0_bp = topo.port0_bp
-        request.cls.lag1_bp = topo.lag1_bp
-        request.cls.vlan_id_int = 10
-        request.cls.src_mac = "00:11:11:11:11:11"
-        request.cls.dst_mac = "00:22:22:22:22:22"
+    def teardown(self, request, npu):
         yield
+        request.cls._cls_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             ["SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid, "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -264,6 +264,7 @@ class TestFdbNoLearn:
         request.cls.port10 = topo.port10
         request.cls.src_mac = "00:11:11:11:11:11"
         request.cls.dst_mac = "00:22:22:22:22:22"
+        npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown_class(self, request, npu):
@@ -564,16 +565,14 @@ class TestFdbLearn:
         request.cls.macs = [
             "00:%02d:%02d:%02d:%02d:%02d" % (i, i, i, i, i) for i in range(1, len(request.cls.src_ports))
         ]
+        npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown_class(self, request, npu):
         yield
         npu.flush_fdb_entries(
             npu.switch_oid,
-            [
-                "SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid,
-                "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
-            ],
+            ["SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid, "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
         )
         npu._topo_initialized = False
 
@@ -3279,8 +3278,5 @@ class TestFdbEvent:
         finally:
             npu.flush_fdb_entries(
                 npu.switch_oid,
-                [
-                "SAI_FDB_FLUSH_ATTR_BV_ID", self.vlan_oid,
-                "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
-            ],
+                ["SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
             )

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -230,19 +230,15 @@ class TestFdbAttribute:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, request, npu, get_topology):
         topo = get_topology
-        
         if not topo:
             return
 
         request.cls.topo = topo
-
         request.cls.vlan_oid = topo.vlan10
         request.cls.mac = "00:11:22:33:44:55"
         request.cls.port0_bp = topo.port0_bp
 
-        npu.create_fdb(
-            request.cls.vlan_oid, request.cls.mac, request.cls.port0_bp
-        )
+        npu.create_fdb(request.cls.vlan_oid, request.cls.mac, request.cls.port0_bp)
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
@@ -252,10 +248,8 @@ class TestFdbAttribute:
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
-                "SAI_FDB_FLUSH_ATTR_BV_ID",
-                request.cls.vlan_oid,
-                "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE",
-                "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
+                "SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid,
+                "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
             ],
         )
 
@@ -292,7 +286,6 @@ class TestFdbNoLearn:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, request, npu, get_topology):
         topo = get_topology
-        
         if not topo:
             return
 
@@ -576,7 +569,6 @@ class TestFdbLearn:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, request, npu, get_topology):
         topo = get_topology
-        
         if not topo:
             return
         request.cls._topo = topo
@@ -981,11 +973,10 @@ class TestFdbMacMove:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, request, npu, get_topology):
         topo = get_topology
-        
         if not topo:
             return
-        request.cls.topo = topo
         
+        request.cls.topo = topo
         request.cls.vlan_oid = topo.vlan10
         request.cls.port0_bp = topo.port0_bp
         request.cls.port1_bp = topo.port1_bp
@@ -2422,7 +2413,6 @@ class TestFdbAge:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, request, npu, get_topology):
         topo = get_topology
-        
         if not topo:
             return
         if len(npu.port_oids) < 25:
@@ -2684,7 +2674,6 @@ class TestFdbMiss:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, request, npu, get_topology):
         topo = get_topology
-        
         if not topo:
             return
         if len(npu.port_oids) <= 26:
@@ -3119,7 +3108,6 @@ class TestFdbEvent:
     @pytest.fixture(scope="function", autouse=True)
     def setup(self, request, npu, get_topology):
         topo = get_topology
-        
         if not topo:
             return
     

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -6,6 +6,7 @@ logger = logging.getLogger(__name__)
 import pytest
 
 import saichallenger.topologies.sai_ptf_topology
+from saichallenger.topologies.sai_ptf_topology import SaiPtfTopologyFixture
 from saichallenger.common.sai_data import SaiObjType
 from ptf.testutils import (
     send_packet,
@@ -24,54 +25,24 @@ def skip_all(testbed_instance):
     if testbed is not None and len(testbed.npu) != 1:
         pytest.skip('invalid for "{}" testbed'.format(testbed.name))
 
-
 @pytest.fixture(scope="module")
-def sai_ptf_topology_context(npu):
-    ctx_holder = {"ctx": None, "topo": None}
-    yield ctx_holder
-    
-    if ctx_holder["ctx"] is not None:
-        try:
-            ctx_holder["ctx"].__exit__(None, None, None)
-        except Exception as e:
-            logger.warning(f"Error closing topology context on teardown: {e}")
-    npu.reset()
+def topology(npu):
+    return SaiPtfTopologyFixture()
 
-@pytest.fixture
-def get_topology(request, npu, sai_ptf_topology_context, prev_test_failed):
-    """
-    Manages topology lifecycle and class initialization state.
-    Returns `topo` ONLY when class initialization is required (first run or recovery after failure).
-    Otherwise returns `None`.
-    """
-    # 1. Recovery on failure: close context, hard reset NPU, and clear class flag
+@pytest.fixture(scope="module", autouse=True)
+def register_topology(npu, topology):
+    npu._topo = topology
+    npu._topo_initialized = False
+    npu._topo.setup(npu)
+    yield
+    npu._topo.teardown()
+ 
+@pytest.fixture(autouse=True)
+def on_prev_test_failure(prev_test_failed, npu):
     if prev_test_failed:
-        if sai_ptf_topology_context.get("ctx") is not None:
-            try:
-                sai_ptf_topology_context["ctx"].__exit__(None, None, None)
-            except Exception as e:
-                logger.warning(f"Error closing topology context: {e}")
-            finally:
-                sai_ptf_topology_context["ctx"] = None
-                sai_ptf_topology_context["topo"] = None
-
         npu.reset()
-        if hasattr(request.cls, "_cls_initialized"):
-            request.cls._cls_initialized = False
-
-    # 2. Skip setup if class is already initialized
-    if getattr(request.cls, "_cls_initialized", False):
-        return None
-
-    # 3. Create fresh topology instance if not present in context
-    if sai_ptf_topology_context["topo"] is None:
-        ctx = saichallenger.topologies.sai_ptf_topology.config(npu)
-        sai_ptf_topology_context["ctx"] = ctx
-        sai_ptf_topology_context["topo"] = ctx.__enter__()
-
-    # 4. Mark class as initialized and return topology
-    request.cls._cls_initialized = True
-    return sai_ptf_topology_context["topo"]
+        npu._topo_initialized = False
+        npu._topo.setup(npu)
 
 
 def _fdb_entry_key(npu, vlan_oid, mac):
@@ -119,13 +90,13 @@ class TestFdbStaticMac:
     Topology for FdbStaticMacTest: provides VLAN 10, lag1, bridge ports and PVIDs.
     """
     @pytest.fixture(autouse=True)
-    def setup(self, request, npu, get_topology):
+    def setup_class(self, request, npu, topology):
         """
         Invoked before EACH test to check topology state, but applies full 
         class configuration ONLY on the first run or after a test failure.
         """
-        topo = get_topology
-        if not topo:
+        topo = topology
+        if npu._topo_initialized:
             return
         
         request.cls.vlan_oid = topo.vlan10
@@ -149,15 +120,16 @@ class TestFdbStaticMac:
         npu.create_fdb(request.cls.vlan_oid, request.cls.macs[0], request.cls.port0_bp)
         npu.create_fdb(request.cls.vlan_oid, request.cls.macs[1], request.cls.port1_bp)
         npu.create_fdb(request.cls.vlan_oid, request.cls.macs[2], request.cls.lag_bp_oid)
+        npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
-    def teardown(self, request, npu):
+    def teardown_class(self, request, npu):
         """
         Teardown fixture: cleans up resources AFTER test execution.
         Starts with `yield`, waits for the test to complete, and flushes FDB entries.
         """
         yield
-        request.cls._cls_initialized = False
+        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
@@ -226,9 +198,9 @@ class TestFdbAttribute:
     Topology for FdbAttributeTest: provides VLAN 10, bridge port and test MAC address.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, get_topology):
-        topo = get_topology
-        if not topo:
+    def setup_class(self, request, npu, topology):
+        topo = topology
+        if npu._topo_initialized:
             return
 
         request.cls.vlan_oid = topo.vlan10
@@ -236,12 +208,12 @@ class TestFdbAttribute:
         request.cls.port0_bp = topo.port0_bp
 
         npu.create_fdb(request.cls.vlan_oid, request.cls.mac, request.cls.port0_bp)
+        npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
-    def teardown(self, request, npu):
+    def teardown_class(self, request, npu):
         yield
-        request.cls._cls_initialized = False
-
+        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
@@ -281,9 +253,9 @@ class TestFdbNoLearn:
     Topology for FdbNoLearnTest: VLAN 10 with port0/port1 and lag1.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, get_topology):
-        topo = get_topology
-        if not topo:
+    def setup_class(self, request, npu, topology):
+        topo = topology
+        if npu._topo_initialized:
             return
 
         request.cls._topo = topo
@@ -301,10 +273,9 @@ class TestFdbNoLearn:
         request.cls.dst_mac = "00:22:22:22:22:22"
 
     @pytest.fixture(scope="class", autouse=True)
-    def teardown(self, request, npu):
+    def teardown_class(self, request, npu):
         yield
-        request.cls._cls_initialized = False
-        
+        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
@@ -564,9 +535,9 @@ class TestFdbLearn:
     Topology for FdbLearnTest: VLAN 10 ports + lag1 and temporarily added lag2 (tagged).
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, get_topology):
-        topo = get_topology
-        if not topo:
+    def setup_class(self, request, npu, topology):
+        topo = topology
+        if npu._topo_initialized:
             return
         request.cls._topo = topo
         request.cls.vlan_oid = topo.vlan10
@@ -603,7 +574,7 @@ class TestFdbLearn:
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
         yield
-        request.cls._cls_initialized = False
+        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             ["SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid, "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
@@ -968,9 +939,9 @@ class TestFdbMacMove:
     static chck_mac on port24_bp, and lag10 (ports 25–27) in VLAN 10.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, get_topology):
-        topo = get_topology
-        if not topo:
+    def setup_class(self, request, npu, topology):
+        topo = topology
+        if npu._topo_initialized:
             return
         
         request.cls.vlan_oid = topo.vlan10
@@ -1048,12 +1019,12 @@ class TestFdbMacMove:
         request.cls._lag10_bp = lag10_bp
         request.cls._lag10_members = lag10_members
         request.cls._vlan10_member4 = vlan10_member4
+        npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
-    def teardown(self, request, npu):
+    def teardown_class(self, request, npu):
         yield
-        request.cls._cls_initialized = False
-
+        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             ["SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid, "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
@@ -1182,9 +1153,9 @@ class TestFdbFlush:
     Topology for FdbFlushTest: port1/port3/lag2 retagged like PTF, trunk stub on port24, dual flood+forward checks.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, get_topology):
-        topo = get_topology
-        if not topo:
+    def setup(self, request, npu, topology):
+        topo = topology
+        if npu._topo_initialized:
             return
 
         if len(npu.port_oids) <= 24:
@@ -1272,11 +1243,12 @@ class TestFdbFlush:
         request.cls._vlan10_member1_ut = vlan10_member1_ut
         request.cls._vlan20_member1_ut = vlan20_member1_ut
         request.cls._vlan20_member2_ut = vlan20_member2_ut
+        npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
         yield
-        request.cls._cls_initialized = False
+        npu._topo_initialized = False
         # SAI-oriented teardown: flush FDB → remove VLAN members (incl. test trunk) →
         # remove objects we created (bridge port). Topology VLANs/LAGs are not removed here.
         _cli = getattr(npu, "sai_client", None)
@@ -2399,9 +2371,9 @@ class TestFdbAge:
     static vrf_mac on port24_bp for routed verification traffic toward CPU path.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, get_topology):
-        topo = get_topology
-        if not topo:
+    def setup(self, request, npu, topology):
+        topo = topology
+        if npu._topo_initialized:
             return
         if len(npu.port_oids) < 25:
             pytest.skip("FdbAgeTest requires physical port index 24 (25 ports)")
@@ -2432,12 +2404,12 @@ class TestFdbAge:
         request.cls._port24_oid = port24_oid
         request.cls._port24_bp = port24_bp
         request.cls._vlan10_member3 = vlan10_member3
+        npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
         yield
-        request.cls._cls_initialized = False
-
+        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
@@ -2659,9 +2631,9 @@ class TestFdbMiss:
     Topology for FdbMissTest: VLAN 100 on ports 24–26, hostif trap group (queue 4) with ARP + LLDP traps.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, get_topology):
-        topo = get_topology
-        if not topo:
+    def setup(self, request, npu, topology):
+        topo = topology
+        if npu._topo_initialized:
             return
         if len(npu.port_oids) <= 26:
             pytest.skip("FdbMissTest requires physical port indices 24–26 (27 ports)")
@@ -2754,12 +2726,12 @@ class TestFdbMiss:
         request.cls._trap_group = trap_group
         request.cls._arp_trap = arp_trap
         request.cls._lldp_trap = lldp_trap
+        npu._topo_initialized = True
             
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
         yield
-        request.cls._cls_initialized = False
-
+        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             ["SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
@@ -3092,9 +3064,9 @@ class TestFdbEvent:
     Topology for FdbEventTest: validate FDB attributes on learn/age/move/flush/delete.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, get_topology):
-        topo = get_topology
-        if not topo:
+    def setup(self, request, npu, topology):
+        topo = topology
+        if npu._topo_initialized:
             return
     
         request.cls.vlan_oid = topo.vlan10
@@ -3103,11 +3075,12 @@ class TestFdbEvent:
         request.cls.vlan_id_int = 10
         request.cls.src_mac = "00:11:11:11:11:11"
         request.cls.dst_mac = "00:22:22:22:22:22"
+        npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
         yield
-        request.cls._cls_initialized = False
+        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             ["SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid, "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -25,64 +25,53 @@ def skip_all(testbed_instance):
         pytest.skip('invalid for "{}" testbed'.format(testbed.name))
 
 
-class TopologyManager:
-    """
-    Manages the SAI PTF topology lifecycle with caching and safe recovery capabilities.
-
-    Execution model:
-    1. A module-scoped fixture instantiates one manager per test module.
-    2. Test classes initialize their specific configuration lazily via a setup 
-       fixture using a class-level initialization flag (`_cls_initialized`).
-    3. `get_topology()` provides access to the active topology, reusing the cached 
-       instance across consecutive successful tests.
-    4. If a test fails (`prev_test_failed`), `reset()` closes the active context, 
-       invalidates the cache, and executes a hard reset on the NPU to guarantee 
-       a clean state for subsequent tests.
-    """
-
-    def __init__(self, npu):
-        """Initializes the manager with the target NPU."""
-        self.npu = npu
-        self._ctx = None
-        self.topo = None
-
-    def get_topology(self):
-        """
-        Retrieves the active topology.
-        Initializes a new `sai_ptf_topology.config()` context if none exists in cache.
-        """
-        if self.topo is None:
-            self._ctx = saichallenger.topologies.sai_ptf_topology.config(self.npu)
-            self.topo = self._ctx.__enter__()
-        return self.topo
-
-    def reset(self):
-        """
-        Tears down the active topology context, invalidates the cache (`topo = None`),
-        and executes a hard reset on the NPU.
-        """
-        if self._ctx is not None:
-            try:
-                self._ctx.__exit__(None, None, None)
-            except Exception as e:
-                logger.warning(f"Error closing topology context during reset: {e}")
-            finally:
-                self._ctx = None
-                self.topo = None
-
-        self.npu.reset()
-
-
 @pytest.fixture(scope="module")
-def sai_ptf_topology_manager(npu):
+def sai_ptf_topology_context(npu):
+    ctx_holder = {"ctx": None, "topo": None}
+    yield ctx_holder
+    
+    if ctx_holder["ctx"] is not None:
+        try:
+            ctx_holder["ctx"].__exit__(None, None, None)
+        except Exception as e:
+            logger.warning(f"Error closing topology context on teardown: {e}")
+    npu.reset()
+
+@pytest.fixture
+def get_topology(request, npu, sai_ptf_topology_context, prev_test_failed):
     """
-    Persists the topology cache across successful tests within the module
-    and executes a final `manager.reset()` upon module completion to ensure 
-    the NPU is left in a clean state.
+    Manages topology lifecycle and class initialization state.
+    Returns `topo` ONLY when class initialization is required (first run or recovery after failure).
+    Otherwise returns `None`.
     """
-    manager = TopologyManager(npu)
-    yield manager
-    manager.reset()
+    # 1. Recovery on failure: close context, hard reset NPU, and clear class flag
+    if prev_test_failed:
+        if sai_ptf_topology_context.get("ctx") is not None:
+            try:
+                sai_ptf_topology_context["ctx"].__exit__(None, None, None)
+            except Exception as e:
+                logger.warning(f"Error closing topology context: {e}")
+            finally:
+                sai_ptf_topology_context["ctx"] = None
+                sai_ptf_topology_context["topo"] = None
+
+        npu.reset()
+        if hasattr(request.cls, "_cls_initialized"):
+            request.cls._cls_initialized = False
+
+    # 2. Skip setup if class is already initialized
+    if getattr(request.cls, "_cls_initialized", False):
+        return None
+
+    # 3. Create fresh topology instance if not present in context
+    if sai_ptf_topology_context["topo"] is None:
+        ctx = saichallenger.topologies.sai_ptf_topology.config(npu)
+        sai_ptf_topology_context["ctx"] = ctx
+        sai_ptf_topology_context["topo"] = ctx.__enter__()
+
+    # 4. Mark class as initialized and return topology
+    request.cls._cls_initialized = True
+    return sai_ptf_topology_context["topo"]
 
 
 def _fdb_entry_key(npu, vlan_oid, mac):
@@ -129,42 +118,39 @@ class TestFdbStaticMac:
     """
     Topology for FdbStaticMacTest: provides VLAN 10, lag1, bridge ports and PVIDs.
     """
-    @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
+    @pytest.fixture(autouse=True)
+    def setup(self, request, npu, get_topology):
         """
         Invoked before EACH test to check topology state, but applies full 
         class configuration ONLY on the first run or after a test failure.
         """
-        if prev_test_failed:
-            sai_ptf_topology_manager.reset()
-            request.cls._cls_initialized = False
+        topo = get_topology
 
-        if not getattr(request.cls, "_cls_initialized", False):
-            topo = sai_ptf_topology_manager.get_topology()
+        if not topo:
+            return
+        
+        request.cls.topo = topo
+        request.cls.vlan_oid = topo.vlan10
+        request.cls.vlan_id_int = 10
+        request.cls.lag_bp_oid = topo.lag1_bp
+        request.cls.dev_port0 = 0
+        request.cls.dev_port1 = 1
+        request.cls.lag_dev_ports = [4, 5, 6]
+        request.cls.port0_bp = topo.port0_bp
+        request.cls.port1_bp = topo.port1_bp
+        request.cls.macs = []
 
-            request.cls.topo = topo
-            request.cls.vlan_oid = topo.vlan10
-            request.cls.vlan_id_int = 10
-            request.cls.lag_bp_oid = topo.lag1_bp
-            request.cls.dev_port0 = 0
-            request.cls.dev_port1 = 1
-            request.cls.lag_dev_ports = [4, 5, 6]
-            request.cls.port0_bp = topo.port0_bp
-            request.cls.port1_bp = topo.port1_bp
-            request.cls.macs = []
+        for i in range(1, 4):
+            request.cls.macs.append("00:%02d:%02d:%02d:%02d:%02d" % (i, i, i, i, i))
+        request.cls.dst_port_groups = [
+            [request.cls.dev_port0],
+            [request.cls.dev_port1],
+            request.cls.lag_dev_ports,
+        ]
 
-            for i in range(1, 4):
-                request.cls.macs.append("00:%02d:%02d:%02d:%02d:%02d" % (i, i, i, i, i))
-            request.cls.dst_port_groups = [
-                [request.cls.dev_port0],
-                [request.cls.dev_port1],
-                request.cls.lag_dev_ports,
-            ]
-
-            npu.create_fdb(request.cls.vlan_oid, request.cls.macs[0], request.cls.port0_bp)
-            npu.create_fdb(request.cls.vlan_oid, request.cls.macs[1], request.cls.port1_bp)
-            npu.create_fdb(request.cls.vlan_oid, request.cls.macs[2], request.cls.lag_bp_oid)
-            request.cls._cls_initialized = True
+        npu.create_fdb(request.cls.vlan_oid, request.cls.macs[0], request.cls.port0_bp)
+        npu.create_fdb(request.cls.vlan_oid, request.cls.macs[1], request.cls.port1_bp)
+        npu.create_fdb(request.cls.vlan_oid, request.cls.macs[2], request.cls.lag_bp_oid)
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
@@ -242,23 +228,21 @@ class TestFdbAttribute:
     Topology for FdbAttributeTest: provides VLAN 10, bridge port and test MAC address.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
-        if prev_test_failed:
-            sai_ptf_topology_manager.reset()
+    def setup(self, request, npu, get_topology):
+        topo = get_topology
+        
+        if not topo:
+            return
 
-        if not getattr(request.cls, "_cls_initialized", False):
-            topo = sai_ptf_topology_manager.get_topology()
+        request.cls.topo = topo
 
-            request.cls.topo = topo
+        request.cls.vlan_oid = topo.vlan10
+        request.cls.mac = "00:11:22:33:44:55"
+        request.cls.port0_bp = topo.port0_bp
 
-            request.cls.vlan_oid = topo.vlan10
-            request.cls.mac = "00:11:22:33:44:55"
-            request.cls.port0_bp = topo.port0_bp
-
-            npu.create_fdb(
-                request.cls.vlan_oid, request.cls.mac, request.cls.port0_bp
-            )
-            request.cls._cls_initialized = True
+        npu.create_fdb(
+            request.cls.vlan_oid, request.cls.mac, request.cls.port0_bp
+        )
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
@@ -306,28 +290,25 @@ class TestFdbNoLearn:
     Topology for FdbNoLearnTest: VLAN 10 with port0/port1 and lag1.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, sai_ptf_topology_manager, prev_test_failed):
-        if prev_test_failed:
-            sai_ptf_topology_manager.reset()
-            request.cls._cls_initialized = False
+    def setup(self, request, npu, get_topology):
+        topo = get_topology
+        
+        if not topo:
+            return
 
-        if not getattr(request.cls, "_cls_initialized", False):
-            topo = sai_ptf_topology_manager.get_topology()
-
-            request.cls._topo = topo
-            request.cls.vlan_oid = topo.vlan10
-            request.cls.vlan_id_int = 10
-            request.cls.port0_bp = topo.port0_bp
-            request.cls.port1_bp = topo.port1_bp
-            request.cls.lag1_bp = topo.lag1_bp
-            request.cls.vlan10_member0 = topo.vlan10_member0
-            request.cls.dev_port0 = 0
-            request.cls.dev_port1 = 1
-            request.cls.lag_ports = [4, 5, 6]
-            request.cls.port10 = topo.port10
-            request.cls.src_mac = "00:11:11:11:11:11"
-            request.cls.dst_mac = "00:22:22:22:22:22"
-            request.cls._cls_initialized = True
+        request.cls._topo = topo
+        request.cls.vlan_oid = topo.vlan10
+        request.cls.vlan_id_int = 10
+        request.cls.port0_bp = topo.port0_bp
+        request.cls.port1_bp = topo.port1_bp
+        request.cls.lag1_bp = topo.lag1_bp
+        request.cls.vlan10_member0 = topo.vlan10_member0
+        request.cls.dev_port0 = 0
+        request.cls.dev_port1 = 1
+        request.cls.lag_ports = [4, 5, 6]
+        request.cls.port10 = topo.port10
+        request.cls.src_mac = "00:11:11:11:11:11"
+        request.cls.dst_mac = "00:22:22:22:22:22"
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
@@ -593,45 +574,42 @@ class TestFdbLearn:
     Topology for FdbLearnTest: VLAN 10 ports + lag1 and temporarily added lag2 (tagged).
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
-        if prev_test_failed:
-            sai_ptf_topology_manager.reset()
-            request.cls._cls_initialized = False
-    
-        if not getattr(request.cls, "_cls_initialized", False):
-            topo = sai_ptf_topology_manager.get_topology()
-            request.cls._topo = topo
-            request.cls.vlan_oid = topo.vlan10
-            request.cls.vlan_id_int = 10
-            request.cls.dev_port0 = 0
-            request.cls.dev_port1 = 1
-            request.cls.utg_lag_ports = [4, 5, 6]
-            request.cls.tg_lag_ports = [7, 8, 9]
-            request.cls.dst_port_groups = [
-                [request.cls.dev_port0],
-                [request.cls.dev_port1],
-                request.cls.utg_lag_ports,
-                request.cls.tg_lag_ports,
-            ]
-            request.cls.port0_bp = topo.port0_bp
-            request.cls.port1_bp = topo.port1_bp
-            request.cls.lag1_bp = topo.lag1_bp
-            request.cls.lag2_bp = topo.lag2_bp
-            request.cls.lag1 = topo.lag1
-            request.cls.vlan10_member1 = topo.vlan10_member1
-            request.cls.lag1_member5 = topo.lag1_member5
-            request.cls.vlan10_member_lag2 = npu.create_vlan_member(
-                request.cls.vlan_oid, request.cls.lag2_bp, "SAI_VLAN_TAGGING_MODE_TAGGED"
-            )
-            request.cls.src_ports = [
-                request.cls.dev_port0,
-                request.cls.dev_port1,
-                4, 5, 6, 7, 8, 9,
-            ]
-            request.cls.macs = [
-                "00:%02d:%02d:%02d:%02d:%02d" % (i, i, i, i, i) for i in range(1, len(request.cls.src_ports))
-            ]
-            request.cls._cls_initialized = True
+    def setup(self, request, npu, get_topology):
+        topo = get_topology
+        
+        if not topo:
+            return
+        request.cls._topo = topo
+        request.cls.vlan_oid = topo.vlan10
+        request.cls.vlan_id_int = 10
+        request.cls.dev_port0 = 0
+        request.cls.dev_port1 = 1
+        request.cls.utg_lag_ports = [4, 5, 6]
+        request.cls.tg_lag_ports = [7, 8, 9]
+        request.cls.dst_port_groups = [
+            [request.cls.dev_port0],
+            [request.cls.dev_port1],
+            request.cls.utg_lag_ports,
+            request.cls.tg_lag_ports,
+        ]
+        request.cls.port0_bp = topo.port0_bp
+        request.cls.port1_bp = topo.port1_bp
+        request.cls.lag1_bp = topo.lag1_bp
+        request.cls.lag2_bp = topo.lag2_bp
+        request.cls.lag1 = topo.lag1
+        request.cls.vlan10_member1 = topo.vlan10_member1
+        request.cls.lag1_member5 = topo.lag1_member5
+        request.cls.vlan10_member_lag2 = npu.create_vlan_member(
+            request.cls.vlan_oid, request.cls.lag2_bp, "SAI_VLAN_TAGGING_MODE_TAGGED"
+        )
+        request.cls.src_ports = [
+            request.cls.dev_port0,
+            request.cls.dev_port1,
+            4, 5, 6, 7, 8, 9,
+        ]
+        request.cls.macs = [
+            "00:%02d:%02d:%02d:%02d:%02d" % (i, i, i, i, i) for i in range(1, len(request.cls.src_ports))
+        ]
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
@@ -1001,94 +979,88 @@ class TestFdbMacMove:
     static chck_mac on port24_bp, and lag10 (ports 25–27) in VLAN 10.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
-        if prev_test_failed:
-            sai_ptf_topology_manager.reset()
-            request.cls._cls_initialized = False
+    def setup(self, request, npu, get_topology):
+        topo = get_topology
+        
+        if not topo:
+            return
+        request.cls.topo = topo
+        
+        request.cls.vlan_oid = topo.vlan10
+        request.cls.port0_bp = topo.port0_bp
+        request.cls.port1_bp = topo.port1_bp
+        request.cls.lag1_bp = topo.lag1_bp
+        request.cls.port0 = topo.port0
+        request.cls.port1 = topo.port1
+        request.cls.lag1 = topo.lag1
+        request.cls.dev_port0 = 0
+        request.cls.dev_port1 = 1
+        request.cls.dev_port5 = 5
+        request.cls.dev_port24 = 24
+        request.cls.dev_port27 = 27
+        request.cls.lag1_ports = [4, 5, 6]
+        request.cls.lag3_ports = [25, 26, 27]
+        request.cls.moving_mac = "00:11:22:33:44:55"
+        request.cls.chck_mac = "00:11:11:11:11:11"
 
-        if not getattr(request.cls, "_cls_initialized", False):
-            if len(npu.port_oids) < 28:
-                            pytest.skip("FdbMacMoveTest requires physical port indices 0–27 (28 ports)")
-            
-            topo = sai_ptf_topology_manager.get_topology()
-            request.cls.topo = topo
-            
-            request.cls.vlan_oid = topo.vlan10
-            request.cls.port0_bp = topo.port0_bp
-            request.cls.port1_bp = topo.port1_bp
-            request.cls.lag1_bp = topo.lag1_bp
-            request.cls.port0 = topo.port0
-            request.cls.port1 = topo.port1
-            request.cls.lag1 = topo.lag1
-            request.cls.dev_port0 = 0
-            request.cls.dev_port1 = 1
-            request.cls.dev_port5 = 5
-            request.cls.dev_port24 = 24
-            request.cls.dev_port27 = 27
-            request.cls.lag1_ports = [4, 5, 6]
-            request.cls.lag3_ports = [25, 26, 27]
-            request.cls.moving_mac = "00:11:22:33:44:55"
-            request.cls.chck_mac = "00:11:11:11:11:11"
+        old_vlan10_member1 = topo.vlan10_member1
+        npu.remove(old_vlan10_member1)
+        vlan10_member1_ut = npu.create_vlan_member(
+            request.cls.vlan_oid, topo.port1_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
+        )
+        npu.set(topo.port1, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
 
-            old_vlan10_member1 = topo.vlan10_member1
-            npu.remove(old_vlan10_member1)
-            vlan10_member1_ut = npu.create_vlan_member(
-                request.cls.vlan_oid, topo.port1_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
-            )
-            npu.set(topo.port1, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
+        port24_oid = npu.port_oids[24]
+        port24_bp = npu.create(
+            SaiObjType.BRIDGE_PORT,
+            [
+                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
+                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+            ],
+        )
+        vlan10_member3 = npu.create_vlan_member(
+            request.cls.vlan_oid, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
+        )
+        npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
 
-            port24_oid = npu.port_oids[24]
-            port24_bp = npu.create(
-                SaiObjType.BRIDGE_PORT,
-                [
-                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
-                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-                ],
-            )
-            vlan10_member3 = npu.create_vlan_member(
-                request.cls.vlan_oid, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
-            )
-            npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
-
-            lag10 = npu.create(SaiObjType.LAG, [])
-            lag10_bp = npu.create(
-                SaiObjType.BRIDGE_PORT,
-                [
-                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", lag10,
-                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-                ],
-            )
-            lag10_members = []
-            for pidx in (25, 26, 27):
-                lag10_members.append(
-                    npu.create(
-                        SaiObjType.LAG_MEMBER,
-                        [
-                            "SAI_LAG_MEMBER_ATTR_LAG_ID", lag10,
-                            "SAI_LAG_MEMBER_ATTR_PORT_ID", npu.port_oids[pidx],
-                        ],
-                    )
+        lag10 = npu.create(SaiObjType.LAG, [])
+        lag10_bp = npu.create(
+            SaiObjType.BRIDGE_PORT,
+            [
+                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                "SAI_BRIDGE_PORT_ATTR_PORT_ID", lag10,
+                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+            ],
+        )
+        lag10_members = []
+        for pidx in (25, 26, 27):
+            lag10_members.append(
+                npu.create(
+                    SaiObjType.LAG_MEMBER,
+                    [
+                        "SAI_LAG_MEMBER_ATTR_LAG_ID", lag10,
+                        "SAI_LAG_MEMBER_ATTR_PORT_ID", npu.port_oids[pidx],
+                    ],
                 )
-            vlan10_member4 = npu.create_vlan_member(
-                request.cls.vlan_oid, lag10_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
             )
-            npu.set(lag10, ["SAI_LAG_ATTR_PORT_VLAN_ID", "10"])
+        vlan10_member4 = npu.create_vlan_member(
+            request.cls.vlan_oid, lag10_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
+        )
+        npu.set(lag10, ["SAI_LAG_ATTR_PORT_VLAN_ID", "10"])
 
-            request.cls.lag10_bp = lag10_bp
-            request.cls.port24_bp = port24_bp
-            npu.create_fdb(request.cls.vlan_oid, request.cls.chck_mac, port24_bp)
+        request.cls.lag10_bp = lag10_bp
+        request.cls.port24_bp = port24_bp
+        npu.create_fdb(request.cls.vlan_oid, request.cls.chck_mac, port24_bp)
 
-            request.cls._topo = topo
-            request.cls._vlan10_member1_ut = vlan10_member1_ut
-            request.cls._port24_oid = port24_oid
-            request.cls._vlan10_member3 = vlan10_member3
-            request.cls._lag10 = lag10
-            request.cls._lag10_bp = lag10_bp
-            request.cls._lag10_members = lag10_members
-            request.cls._vlan10_member4 = vlan10_member4
-            request.cls._cls_initialized = True
+        request.cls._topo = topo
+        request.cls._vlan10_member1_ut = vlan10_member1_ut
+        request.cls._port24_oid = port24_oid
+        request.cls._vlan10_member3 = vlan10_member3
+        request.cls._lag10 = lag10
+        request.cls._lag10_bp = lag10_bp
+        request.cls._lag10_members = lag10_members
+        request.cls._vlan10_member4 = vlan10_member4
             
 
     @pytest.fixture(scope="class", autouse=True)
@@ -1226,34 +1198,21 @@ class TestFdbFlush:
     """
     Topology for FdbFlushTest: port1/port3/lag2 retagged like PTF, trunk stub on port24, dual flood+forward checks.
     """
-
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
-        """Setup topology and test state before execution."""
-        if prev_test_failed:
-            sai_ptf_topology_manager.reset()
-            request.cls._cls_initialized = False
+    def setup(self, request, npu, get_topology):
+        topo = get_topology
+        if not topo:
+            return
 
-        if not getattr(request.cls, "_cls_initialized", False):
-            if len(npu.port_oids) <= 24:
-                pytest.skip("FdbFlushTest requires physical port index 24 (25 ports)")
+        if len(npu.port_oids) <= 24:
+            pytest.skip("FdbFlushTest requires physical port index 24 (25 ports)")
 
-            topo = sai_ptf_topology_manager.get_topology()
-
-            _m = npu.get_vlan_member(topo.vlan10, topo.port1_bp)
-            if _m is not None:
-                npu.remove(_m)
-            vlan10_member1_ut = npu.create_vlan_member(
-                topo.vlan10, topo.port1_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
-            )
-            npu.set(topo.port1, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
         vlan10_oid = None
         vlan20_oid = None
         port24_bp = None
         vlan10_member1_ut = None
         vlan20_member1_ut = None
         vlan20_member2_ut = None
-
 
         _m = npu.get_vlan_member(topo.vlan10, topo.port1_bp)
         if _m is not None:
@@ -1279,6 +1238,7 @@ class TestFdbFlush:
         )
         npu.set(topo.lag2, ["SAI_LAG_ATTR_PORT_VLAN_ID", "20"])
 
+
         port24_bp = npu.create(
             SaiObjType.BRIDGE_PORT,
             [
@@ -1303,6 +1263,7 @@ class TestFdbFlush:
         request.cls.trunk_port_bp = port24_bp
         request.cls.trunk_dev_port = 24
 
+
         request.cls.dev_port0 = 0
         request.cls.dev_port1 = 1
         request.cls.dev_port2 = 2
@@ -1321,6 +1282,7 @@ class TestFdbFlush:
         request.cls.vlan20_stat_macs = ["00:20:00:%02d:%02d:%02d" % (i, i, i) for i in range(1, 6)]
         request.cls.vlan20_dyn_macs = ["00:20:ff:%02d:%02d:%02d" % (i, i, i) for i in range(1, 6)]
 
+
         request.cls.tp10_stat_mac = "00:10:00:66:66:66"
         request.cls.tp10_dyn_mac = "00:10:ff:66:66:66"
         request.cls.tp20_stat_mac = "00:20:00:66:66:66"
@@ -1331,11 +1293,11 @@ class TestFdbFlush:
         request.cls._vlan10_member1_ut = vlan10_member1_ut
         request.cls._vlan20_member1_ut = vlan20_member1_ut
         request.cls._vlan20_member2_ut = vlan20_member2_ut
-        request.cls._cls_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
         yield
+        request.cls._cls_initialized = False
         # SAI-oriented teardown: flush FDB → remove VLAN members (incl. test trunk) →
         # remove objects we created (bridge port). Topology VLANs/LAGs are not removed here.
         _cli = getattr(npu, "sai_client", None)
@@ -2458,48 +2420,41 @@ class TestFdbAge:
     static vrf_mac on port24_bp for routed verification traffic toward CPU path.
     """
     @pytest.fixture(scope="function", autouse=True)
+    def setup(self, request, npu, get_topology):
+        topo = get_topology
+        
+        if not topo:
+            return
+        if len(npu.port_oids) < 25:
+                pytest.skip("FdbAgeTest requires physical port index 24 (25 ports)")
 
-    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
+        request.cls.topo = topo
+        request.cls.vlan_oid = topo.vlan10
+        request.cls.vlan_id_int = 10
+        request.cls.age_time = 10
+        request.cls.vrf_mac = "00:12:34:56:78:90"
+        request.cls.vrf_port_dev = 24
 
-        if prev_test_failed:
-            sai_ptf_topology_manager.reset()
-            request.cls._cls_initialized = False
-            
+        npu.set(npu.switch_oid, ["SAI_SWITCH_ATTR_FDB_AGING_TIME", str(request.cls.age_time)])
 
-        if not getattr(request.cls, "_cls_initialized", False):
-            if len(npu.port_oids) < 25:
-                    pytest.skip("FdbAgeTest requires physical port index 24 (25 ports)")
+        port24_oid = npu.port_oids[24]
+        port24_bp = npu.create(
+            SaiObjType.BRIDGE_PORT,
+            [
+                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
+                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+            ],
+        )
+        vlan10_member3 = npu.create_vlan_member(
+            request.cls.vlan_oid, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
+        )
+        npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", str(request.cls.vlan_id_int)])
+        npu.create_fdb(request.cls.vlan_oid, request.cls.vrf_mac, port24_bp)
 
-            topo = sai_ptf_topology_manager.get_topology()
-
-            request.cls.topo = topo
-            request.cls.vlan_oid = topo.vlan10
-            request.cls.vlan_id_int = 10
-            request.cls.age_time = 10
-            request.cls.vrf_mac = "00:12:34:56:78:90"
-            request.cls.vrf_port_dev = 24
-
-            npu.set(npu.switch_oid, ["SAI_SWITCH_ATTR_FDB_AGING_TIME", str(request.cls.age_time)])
-
-            port24_oid = npu.port_oids[24]
-            port24_bp = npu.create(
-                SaiObjType.BRIDGE_PORT,
-                [
-                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
-                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-                ],
-            )
-            vlan10_member3 = npu.create_vlan_member(
-                request.cls.vlan_oid, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED"
-            )
-            npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", str(request.cls.vlan_id_int)])
-            npu.create_fdb(request.cls.vlan_oid, request.cls.vrf_mac, port24_bp)
-
-            request.cls._port24_oid = port24_oid
-            request.cls._port24_bp = port24_bp
-            request.cls._vlan10_member3 = vlan10_member3
-            request.cls._cls_initialized = True
+        request.cls._port24_oid = port24_oid
+        request.cls._port24_bp = port24_bp
+        request.cls._vlan10_member3 = vlan10_member3
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
@@ -2727,107 +2682,103 @@ class TestFdbMiss:
     Topology for FdbMissTest: VLAN 100 on ports 24–26, hostif trap group (queue 4) with ARP + LLDP traps.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, sai_ptf_topology_manager, prev_test_failed):
-  
-        if prev_test_failed:
-            sai_ptf_topology_manager.reset()
-            request.cls._cls_initialized = False
+    def setup(self, request, npu, get_topology):
+        topo = get_topology
+        
+        if not topo:
+            return
+        if len(npu.port_oids) <= 26:
+            pytest.skip("FdbMissTest requires physical port indices 24–26 (27 ports)")
 
-        if not getattr(request.cls, "_cls_initialized", False):
-            if len(npu.port_oids) <= 26:
-                pytest.skip("FdbMissTest requires physical port indices 24–26 (27 ports)")
+        request.cls.topo = topo
+        port24_oid = npu.port_oids[24]
+        port25_oid = npu.port_oids[25]
+        port26_oid = npu.port_oids[26]
 
-            topo =  sai_ptf_topology_manager.get_topology()
-            port24_oid = npu.port_oids[24]
-            port25_oid = npu.port_oids[25]
-            port26_oid = npu.port_oids[26]
+        port24_bp = npu.create(
+            SaiObjType.BRIDGE_PORT,
+            [
+                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
+                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+            ],
+        )
+        port25_bp = npu.create(
+            SaiObjType.BRIDGE_PORT,
+            [
+                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                "SAI_BRIDGE_PORT_ATTR_PORT_ID", port25_oid,
+                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+            ],
+        )
+        port26_bp = npu.create(
+            SaiObjType.BRIDGE_PORT,
+            [
+                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                "SAI_BRIDGE_PORT_ATTR_PORT_ID", port26_oid,
+                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+            ],
+        )
 
-            port24_bp = npu.create(
-                SaiObjType.BRIDGE_PORT,
-                [
-                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", port24_oid,
-                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-                ],
-            )
-            port25_bp = npu.create(
-                SaiObjType.BRIDGE_PORT,
-                [
-                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", port25_oid,
-                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-                ],
-            )
-            port26_bp = npu.create(
-                SaiObjType.BRIDGE_PORT,
-                [
-                    "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                    "SAI_BRIDGE_PORT_ATTR_PORT_ID", port26_oid,
-                    "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
-                ],
-            )
+        vlan100 = npu.create(SaiObjType.VLAN, ["SAI_VLAN_ATTR_VLAN_ID", "100"])
+        vm0 = npu.create_vlan_member(vlan100, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+        vm1 = npu.create_vlan_member(vlan100, port25_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+        vm2 = npu.create_vlan_member(vlan100, port26_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
 
-            vlan100 = npu.create(SaiObjType.VLAN, ["SAI_VLAN_ATTR_VLAN_ID", "100"])
-            vm0 = npu.create_vlan_member(vlan100, port24_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
-            vm1 = npu.create_vlan_member(vlan100, port25_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
-            vm2 = npu.create_vlan_member(vlan100, port26_bp, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+        npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
+        npu.set(port25_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
+        npu.set(port26_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
 
-            npu.set(port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
-            npu.set(port25_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
-            npu.set(port26_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "100"])
+        trap_group = npu.create(
+            "SAI_OBJECT_TYPE_HOSTIF_TRAP_GROUP",
+            ["SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE", "4"],
+        )
+        arp_trap = npu.create(
+            "SAI_OBJECT_TYPE_HOSTIF_TRAP",
+            [
+                "SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE", "SAI_HOSTIF_TRAP_TYPE_ARP_REQUEST",
+                "SAI_HOSTIF_TRAP_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_TRAP",
+                "SAI_HOSTIF_TRAP_ATTR_TRAP_GROUP", trap_group,
+            ],
+        )
+        lldp_trap = npu.create(
+            "SAI_OBJECT_TYPE_HOSTIF_TRAP",
+            [
+                "SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE", "SAI_HOSTIF_TRAP_TYPE_LLDP",
+                "SAI_HOSTIF_TRAP_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_TRAP",
+                "SAI_HOSTIF_TRAP_ATTR_TRAP_GROUP", trap_group,
+            ],
+        )
 
-            trap_group = npu.create(
-                "SAI_OBJECT_TYPE_HOSTIF_TRAP_GROUP",
-                ["SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE", "4"],
-            )
-            arp_trap = npu.create(
-                "SAI_OBJECT_TYPE_HOSTIF_TRAP",
-                [
-                    "SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE", "SAI_HOSTIF_TRAP_TYPE_ARP_REQUEST",
-                    "SAI_HOSTIF_TRAP_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_TRAP",
-                    "SAI_HOSTIF_TRAP_ATTR_TRAP_GROUP", trap_group,
-                ],
-            )
-            lldp_trap = npu.create(
-                "SAI_OBJECT_TYPE_HOSTIF_TRAP",
-                [
-                    "SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE", "SAI_HOSTIF_TRAP_TYPE_LLDP",
-                    "SAI_HOSTIF_TRAP_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_TRAP",
-                    "SAI_HOSTIF_TRAP_ATTR_TRAP_GROUP", trap_group,
-                ],
-            )
+        request.cls.vlan_oid = vlan100
+        request.cls.send_port = 24
+        request.cls.flood_ports = [25, 26]
+        request.cls.src_mac = "00:11:11:11:11:11"
+        request.cls.dst_mac = "00:22:22:22:22:22"
+        request.cls.mcast_mac = "01:00:5e:11:22:33"
+        request.cls.bcast_mac = "ff:ff:ff:ff:ff:ff"
+        request.cls.lldp_mac = "01:80:c2:00:00:0e"
+        request.cls.ucast_pkt = simple_udp_packet(eth_dst=request.cls.dst_mac, eth_src=request.cls.src_mac)
+        request.cls.mcast_pkt = simple_udp_packet(eth_dst=request.cls.mcast_mac, eth_src=request.cls.src_mac)
+        request.cls.bcast_pkt = simple_udp_packet(eth_dst=request.cls.bcast_mac, eth_src=request.cls.src_mac)
+        request.cls.arp_pkt = simple_arp_packet(arp_op=1, pktlen=100)
+        request.cls.lldp_pkt = simple_eth_packet(
+            eth_dst=request.cls.lldp_mac, eth_src=request.cls.src_mac, pktlen=60, eth_type=0x88cc
+        )
 
-            request.cls.topo = topo
-            request.cls.vlan_oid = vlan100
-            request.cls.send_port = 24
-            request.cls.flood_ports = [25, 26]
-            request.cls.src_mac = "00:11:11:11:11:11"
-            request.cls.dst_mac = "00:22:22:22:22:22"
-            request.cls.mcast_mac = "01:00:5e:11:22:33"
-            request.cls.bcast_mac = "ff:ff:ff:ff:ff:ff"
-            request.cls.lldp_mac = "01:80:c2:00:00:0e"
-            request.cls.ucast_pkt = simple_udp_packet(eth_dst=request.cls.dst_mac, eth_src=request.cls.src_mac)
-            request.cls.mcast_pkt = simple_udp_packet(eth_dst=request.cls.mcast_mac, eth_src=request.cls.src_mac)
-            request.cls.bcast_pkt = simple_udp_packet(eth_dst=request.cls.bcast_mac, eth_src=request.cls.src_mac)
-            request.cls.arp_pkt = simple_arp_packet(arp_op=1, pktlen=100)
-            request.cls.lldp_pkt = simple_eth_packet(
-                eth_dst=request.cls.lldp_mac, eth_src=request.cls.src_mac, pktlen=60, eth_type=0x88cc
-            )
-
-            request.cls._port24_oid = port24_oid
-            request.cls._port25_oid = port25_oid
-            request.cls._port26_oid = port26_oid
-            request.cls._port24_bp = port24_bp
-            request.cls._port25_bp = port25_bp
-            request.cls._port26_bp = port26_bp
-            request.cls._vlan100 = vlan100
-            request.cls._vm0 = vm0
-            request.cls._vm1 = vm1
-            request.cls._vm2 = vm2
-            request.cls._trap_group = trap_group
-            request.cls._arp_trap = arp_trap
-            request.cls._lldp_trap = lldp_trap
-            request.cls._cls_initialized = True
+        request.cls._port24_oid = port24_oid
+        request.cls._port25_oid = port25_oid
+        request.cls._port26_oid = port26_oid
+        request.cls._port24_bp = port24_bp
+        request.cls._port25_bp = port25_bp
+        request.cls._port26_bp = port26_bp
+        request.cls._vlan100 = vlan100
+        request.cls._vm0 = vm0
+        request.cls._vm1 = vm1
+        request.cls._vm2 = vm2
+        request.cls._trap_group = trap_group
+        request.cls._arp_trap = arp_trap
+        request.cls._lldp_trap = lldp_trap
             
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
@@ -3166,22 +3117,19 @@ class TestFdbEvent:
     Topology for FdbEventTest: validate FDB attributes on learn/age/move/flush/delete.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, sai_ptf_topology_manager, prev_test_failed):
-        if prev_test_failed:
-            sai_ptf_topology_manager.reset()
-            request.cls._cls_initialized = False
-
-        if not getattr(request.cls, "_cls_initialized", False):
-            topo = sai_ptf_topology_manager.get_topology()
+    def setup(self, request, npu, get_topology):
+        topo = get_topology
         
-            request.cls.topo = topo
-            request.cls.vlan_oid = topo.vlan10
-            request.cls.port0_bp = topo.port0_bp
-            request.cls.lag1_bp = topo.lag1_bp
-            request.cls.vlan_id_int = 10
-            request.cls.src_mac = "00:11:11:11:11:11"
-            request.cls.dst_mac = "00:22:22:22:22:22"
-            request.cls._cls_initialized = True
+        if not topo:
+            return
+    
+        request.cls.topo = topo
+        request.cls.vlan_oid = topo.vlan10
+        request.cls.port0_bp = topo.port0_bp
+        request.cls.lag1_bp = topo.lag1_bp
+        request.cls.vlan_id_int = 10
+        request.cls.src_mac = "00:11:11:11:11:11"
+        request.cls.dst_mac = "00:22:22:22:22:22"
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -125,11 +125,9 @@ class TestFdbStaticMac:
         class configuration ONLY on the first run or after a test failure.
         """
         topo = get_topology
-
         if not topo:
             return
         
-        request.cls.topo = topo
         request.cls.vlan_oid = topo.vlan10
         request.cls.vlan_id_int = 10
         request.cls.lag_bp_oid = topo.lag1_bp
@@ -233,7 +231,6 @@ class TestFdbAttribute:
         if not topo:
             return
 
-        request.cls.topo = topo
         request.cls.vlan_oid = topo.vlan10
         request.cls.mac = "00:11:22:33:44:55"
         request.cls.port0_bp = topo.port0_bp
@@ -976,7 +973,6 @@ class TestFdbMacMove:
         if not topo:
             return
         
-        request.cls.topo = topo
         request.cls.vlan_oid = topo.vlan10
         request.cls.port0_bp = topo.port0_bp
         request.cls.port1_bp = topo.port1_bp
@@ -1052,15 +1048,11 @@ class TestFdbMacMove:
         request.cls._lag10_bp = lag10_bp
         request.cls._lag10_members = lag10_members
         request.cls._vlan10_member4 = vlan10_member4
-            
 
     @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request, npu):
         yield
         request.cls._cls_initialized = False
-        topo = getattr(request.cls, "_topo", None)
-        if topo is None:
-            return
 
         npu.flush_fdb_entries(
             npu.switch_oid,
@@ -1229,7 +1221,6 @@ class TestFdbFlush:
         )
         npu.set(topo.lag2, ["SAI_LAG_ATTR_PORT_VLAN_ID", "20"])
 
-
         port24_bp = npu.create(
             SaiObjType.BRIDGE_PORT,
             [
@@ -1238,7 +1229,6 @@ class TestFdbFlush:
                 "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
             ],
         )
-
 
         vlan10_oid = topo.vlan10
         vlan20_oid = topo.vlan20
@@ -1253,7 +1243,6 @@ class TestFdbFlush:
         request.cls.port24_bp = port24_bp
         request.cls.trunk_port_bp = port24_bp
         request.cls.trunk_dev_port = 24
-
 
         request.cls.dev_port0 = 0
         request.cls.dev_port1 = 1
@@ -1272,7 +1261,6 @@ class TestFdbFlush:
         request.cls.vlan10_dyn_macs = ["00:10:ff:%02d:%02d:%02d" % (i, i, i) for i in range(1, 6)]
         request.cls.vlan20_stat_macs = ["00:20:00:%02d:%02d:%02d" % (i, i, i) for i in range(1, 6)]
         request.cls.vlan20_dyn_macs = ["00:20:ff:%02d:%02d:%02d" % (i, i, i) for i in range(1, 6)]
-
 
         request.cls.tp10_stat_mac = "00:10:00:66:66:66"
         request.cls.tp10_dyn_mac = "00:10:ff:66:66:66"
@@ -2416,9 +2404,8 @@ class TestFdbAge:
         if not topo:
             return
         if len(npu.port_oids) < 25:
-                pytest.skip("FdbAgeTest requires physical port index 24 (25 ports)")
+            pytest.skip("FdbAgeTest requires physical port index 24 (25 ports)")
 
-        request.cls.topo = topo
         request.cls.vlan_oid = topo.vlan10
         request.cls.vlan_id_int = 10
         request.cls.age_time = 10
@@ -2679,7 +2666,6 @@ class TestFdbMiss:
         if len(npu.port_oids) <= 26:
             pytest.skip("FdbMissTest requires physical port indices 24–26 (27 ports)")
 
-        request.cls.topo = topo
         port24_oid = npu.port_oids[24]
         port25_oid = npu.port_oids[25]
         port26_oid = npu.port_oids[26]
@@ -3111,7 +3097,6 @@ class TestFdbEvent:
         if not topo:
             return
     
-        request.cls.topo = topo
         request.cls.vlan_oid = topo.vlan10
         request.cls.port0_bp = topo.port0_bp
         request.cls.lag1_bp = topo.lag1_bp

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -1,12 +1,9 @@
 import json
 import time
-import logging
-logger = logging.getLogger(__name__)
 
 import pytest
 
-import saichallenger.topologies.sai_ptf_topology
-from saichallenger.topologies.sai_ptf_topology import SaiPtfTopologyFixture
+from saichallenger.topologies.sai_ptf_topology import topology
 from saichallenger.common.sai_data import SaiObjType
 from ptf.testutils import (
     send_packet,
@@ -25,15 +22,11 @@ def skip_all(testbed_instance):
     if testbed is not None and len(testbed.npu) != 1:
         pytest.skip('invalid for "{}" testbed'.format(testbed.name))
 
-@pytest.fixture(scope="module")
-def topology(npu):
-    return SaiPtfTopologyFixture()
-
 @pytest.fixture(scope="module", autouse=True)
 def register_topology(npu, topology):
     npu._topo = topology
     npu._topo_initialized = False
-    npu._topo.setup(npu)
+    npu._topo.setup()
     yield
     npu._topo.teardown()
  
@@ -42,7 +35,7 @@ def on_prev_test_failure(prev_test_failed, npu):
     if prev_test_failed:
         npu.reset()
         npu._topo_initialized = False
-        npu._topo.setup(npu)
+        npu._topo.setup()
 
 
 def _fdb_entry_key(npu, vlan_oid, mac):

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -122,7 +122,6 @@ class TestFdbStaticMac:
         Starts with `yield`, waits for the test to complete, and flushes FDB entries.
         """
         yield
-        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
@@ -130,6 +129,7 @@ class TestFdbStaticMac:
                 "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
             ],
         )
+        npu._topo_initialized = False
 
     def test_fdb_static_mac_forward(self, npu, dataplane):
         """
@@ -206,7 +206,6 @@ class TestFdbAttribute:
     @pytest.fixture(scope="class", autouse=True)
     def teardown_class(self, request, npu):
         yield
-        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
@@ -214,6 +213,7 @@ class TestFdbAttribute:
                 "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
             ],
         )
+        npu._topo_initialized = False
 
     def test_fdb_attribute(self, npu):
         """
@@ -268,7 +268,6 @@ class TestFdbNoLearn:
     @pytest.fixture(scope="class", autouse=True)
     def teardown_class(self, request, npu):
         yield
-        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
@@ -276,6 +275,7 @@ class TestFdbNoLearn:
                 "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
             ],
         )
+        npu._topo_initialized = False
 
     def _flood_from_port0_pkt(self):
         pkt = simple_udp_packet(eth_dst=self.dst_mac, eth_src=self.src_mac, pktlen=100)
@@ -555,6 +555,7 @@ class TestFdbLearn:
         request.cls.vlan10_member_lag2 = npu.create_vlan_member(
             request.cls.vlan_oid, request.cls.lag2_bp, "SAI_VLAN_TAGGING_MODE_TAGGED"
         )
+        topo.def_vlan_member_list.append(request.cls.vlan10_member_lag2)
         request.cls.src_ports = [
             request.cls.dev_port0,
             request.cls.dev_port1,
@@ -565,14 +566,16 @@ class TestFdbLearn:
         ]
 
     @pytest.fixture(scope="class", autouse=True)
-    def teardown(self, request, npu):
+    def teardown_class(self, request, npu):
         yield
-        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
-            ["SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid, "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
+            [
+                "SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid,
+                "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
+            ],
         )
-        npu.remove(request.cls.vlan10_member_lag2)
+        npu._topo_initialized = False
 
     def test_dynamic_mac_learn(self, npu, dataplane):
         """
@@ -1017,7 +1020,6 @@ class TestFdbMacMove:
     @pytest.fixture(scope="class", autouse=True)
     def teardown_class(self, request, npu):
         yield
-        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             ["SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid, "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
@@ -1037,6 +1039,7 @@ class TestFdbMacMove:
             request.cls.vlan_oid, request.cls.port1_bp, "SAI_VLAN_TAGGING_MODE_TAGGED"
         )
         _refresh_topo_vlan_member(request.cls._topo, "vlan10_member1", new_member)
+        npu._topo_initialized = False
 
     def test_dynamic_mac_move(self, npu, dataplane):
         """
@@ -1146,7 +1149,7 @@ class TestFdbFlush:
     Topology for FdbFlushTest: port1/port3/lag2 retagged like PTF, trunk stub on port24, dual flood+forward checks.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, topology):
+    def setup_class(self, request, npu, topology):
         topo = topology
         if npu._topo_initialized:
             return
@@ -1239,9 +1242,8 @@ class TestFdbFlush:
         npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
-    def teardown(self, request, npu):
+    def teardown_class(self, request, npu):
         yield
-        npu._topo_initialized = False
         # SAI-oriented teardown: flush FDB → remove VLAN members (incl. test trunk) →
         # remove objects we created (bridge port). Topology VLANs/LAGs are not removed here.
         _cli = getattr(npu, "sai_client", None)
@@ -1290,6 +1292,7 @@ class TestFdbFlush:
                 request.cls.vlan20, request.cls.lag2_bp, "SAI_VLAN_TAGGING_MODE_TAGGED"
             )
             _refresh_topo_vlan_member(request.cls.topo, "vlan20_member2", new_member)
+        npu._topo_initialized = False
 
     def _prepare_fdb(self, npu, dataplane):
         npu.flush_fdb_entries(npu.switch_oid, ["SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"])
@@ -2364,7 +2367,7 @@ class TestFdbAge:
     static vrf_mac on port24_bp for routed verification traffic toward CPU path.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, topology):
+    def setup_class(self, request, npu, topology):
         topo = topology
         if npu._topo_initialized:
             return
@@ -2400,9 +2403,8 @@ class TestFdbAge:
         npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
-    def teardown(self, request, npu):
+    def teardown_class(self, request, npu):
         yield
-        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             [
@@ -2414,6 +2416,7 @@ class TestFdbAge:
         npu.remove(request.cls._port24_bp)
         npu.set(request.cls._port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", npu.default_vlan_id])
         npu.set(npu.switch_oid, ["SAI_SWITCH_ATTR_FDB_AGING_TIME", "0"])
+        npu._topo_initialized = False
 
     def test_mac_aging_on_port(self, npu, dataplane):
         """
@@ -2624,7 +2627,7 @@ class TestFdbMiss:
     Topology for FdbMissTest: VLAN 100 on ports 24–26, hostif trap group (queue 4) with ARP + LLDP traps.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, topology):
+    def setup_class(self, request, npu, topology):
         topo = topology
         if npu._topo_initialized:
             return
@@ -2722,9 +2725,8 @@ class TestFdbMiss:
         npu._topo_initialized = True
             
     @pytest.fixture(scope="class", autouse=True)
-    def teardown(self, request, npu):
+    def teardown_class(self, request, npu):
         yield
-        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             ["SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
@@ -2743,6 +2745,7 @@ class TestFdbMiss:
         npu.remove(request.cls._port24_bp)
         npu.remove(request.cls._port25_bp)
         npu.remove(request.cls._port26_bp)
+        npu._topo_initialized = False
 
     def _queue_stat(self, npu, queue_oid):
         return npu.get_stats(queue_oid, ["SAI_QUEUE_STAT_PACKETS", ""]).counters()["SAI_QUEUE_STAT_PACKETS"]
@@ -3057,7 +3060,7 @@ class TestFdbEvent:
     Topology for FdbEventTest: validate FDB attributes on learn/age/move/flush/delete.
     """
     @pytest.fixture(scope="function", autouse=True)
-    def setup(self, request, npu, topology):
+    def setup_class(self, request, npu, topology):
         topo = topology
         if npu._topo_initialized:
             return
@@ -3071,13 +3074,13 @@ class TestFdbEvent:
         npu._topo_initialized = True
 
     @pytest.fixture(scope="class", autouse=True)
-    def teardown(self, request, npu):
+    def teardown_class(self, request, npu):
         yield
-        npu._topo_initialized = False
         npu.flush_fdb_entries(
             npu.switch_oid,
             ["SAI_FDB_FLUSH_ATTR_BV_ID", request.cls.vlan_oid, "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
         )
+        npu._topo_initialized = False
 
     def test_mac_learn_event(self, npu, dataplane):
         """
@@ -3276,5 +3279,8 @@ class TestFdbEvent:
         finally:
             npu.flush_fdb_entries(
                 npu.switch_oid,
-                ["SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL"],
+                [
+                "SAI_FDB_FLUSH_ATTR_BV_ID", self.vlan_oid,
+                "SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_ALL",
+            ],
             )

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -235,7 +235,6 @@ class TestL2Vlan:
     @pytest.fixture(scope="class", autouse=True)
     def teardown_class(self, request, npu):
         yield
-        npu._topo_initialized = False
         npu.set(request.cls.topo.port2, ["SAI_PORT_ATTR_PORT_VLAN_ID", "20"])
 
         for bv in (
@@ -307,6 +306,7 @@ class TestL2Vlan:
         npu.remove(request.cls.topo.port26_bp)
         npu.remove(request.cls.topo.port25_bp)
         npu.remove(request.cls.topo.port24_bp)
+        npu._topo_initialized = False
 
     def _inc_vlan10_ucast(self):
         type(self).i_pkt_count += 1

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -83,7 +83,7 @@ class TestL2Vlan:
     def setup_class(self, request, npu, topology):
         topo = topology
         if npu._topo_initialized:
-                    return
+            return
         
         if len(npu.port_oids) < 32:
             pytest.skip("TestL2Vlan requires at least 32 ports (indices 0..31)")

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -3,7 +3,7 @@ import time
 import pytest
 from scapy.layers.l2 import Dot1Q
 
-import saichallenger.topologies.sai_ptf_topology
+from saichallenger.topologies.sai_ptf_topology import topology
 from saichallenger.common.sai_data import SaiObjType
 from ptf.testutils import (
     send_packet,
@@ -25,16 +25,20 @@ def skip_all(testbed_instance):
         pytest.skip('invalid for "{}" testbed'.format(testbed.name))
 
 
+@pytest.fixture(scope="module", autouse=True)
+def register_topology(npu, topology):
+    npu._topo = topology
+    npu._topo_initialized = False
+    npu._topo.setup()
+    yield
+    npu._topo.teardown()
+ 
 @pytest.fixture(autouse=True)
 def on_prev_test_failure(prev_test_failed, npu):
     if prev_test_failed:
         npu.reset()
-
-
-@pytest.fixture(scope="module")
-def sai_ptf_topology(npu):
-    with saichallenger.topologies.sai_ptf_topology.config(npu) as topo:
-        yield topo
+        npu._topo_initialized = False
+        npu._topo.setup()
 
 
 def _vlan_data(vlan_id, ports, untagged, large_port):
@@ -75,9 +79,12 @@ def _vlan_stats_map(npu, vlan_oid):
 
 
 class TestL2Vlan:
-    @pytest.fixture(scope="class", autouse=True)
-    def setup_teardown(self, request, npu, sai_ptf_topology):
-        topo = sai_ptf_topology
+    @pytest.fixture(autouse=True)
+    def setup_class(self, request, npu, topology):
+        topo = topology
+        if npu._topo_initialized:
+                    return
+        
         if len(npu.port_oids) < 32:
             pytest.skip("TestL2Vlan requires at least 32 ports (indices 0..31)")
 
@@ -223,9 +230,12 @@ class TestL2Vlan:
             request.cls.vlan70, request.cls.lag11_bp,
             "SAI_VLAN_TAGGING_MODE_UNTAGGED",
         )
+        npu._topo_initialized = True
 
+    @pytest.fixture(scope="class", autouse=True)
+    def teardown_class(self, request, npu):
         yield
-
+        npu._topo_initialized = False
         npu.set(request.cls.topo.port2, ["SAI_PORT_ATTR_PORT_VLAN_ID", "20"])
 
         for bv in (

--- a/topologies/sai_ptf_topology.py
+++ b/topologies/sai_ptf_topology.py
@@ -96,9 +96,12 @@ class SaiPtfTopologyMixin:
     default_vlan_id: str
     default_1q_bridge: str
 
-    def setup(self, npu: Any) -> None:
-        """Initialize NPU reference, build aliases and bring up the full topology."""
+    def __init__(self, npu: Any) -> None:
         self.npu = npu
+
+    def setup(self) -> None:
+        """Initialize NPU reference, build aliases and bring up the full topology."""
+
         self.def_bridge_port_list = []
         self.def_lag_list = []
         self.def_lag_member_list = []
@@ -107,19 +110,19 @@ class SaiPtfTopologyMixin:
         self.def_rif_list = []
         self._saved_default_vlan_members: List[Dict[str, str]] = []
 
-        self.switch_id = npu.switch_oid
-        self.default_vrf = npu.default_vrf_oid
-        self.default_vlan_oid = npu.default_vlan_oid
-        self.default_vlan_id = npu.default_vlan_id
-        self.default_1q_bridge = npu.dot1q_br_oid
+        self.switch_id = self.npu.switch_oid
+        self.default_vrf = self.npu.default_vrf_oid
+        self.default_vlan_oid = self.npu.default_vlan_oid
+        self.default_vlan_id = self.npu.default_vlan_id
+        self.default_1q_bridge = self.npu.dot1q_br_oid
 
-        if len(npu.port_oids) < 24:
+        if len(self.npu.port_oids) < 24:
             pytest.skip(
                 "SaiPtfTopologyMixin requires at least 24 active ports (indices 0 through 23)"
             )
 
         for i in range(24):
-            setattr(self, "port%d" % i, npu.port_oids[i])
+            setattr(self, "port%d" % i, self.npu.port_oids[i])
 
         self.remove_default_vlan_members()
         self.remove_default_bridge_ports()
@@ -421,9 +424,14 @@ class SaiPtfTopologyFixture(SaiPtfTopologyMixin):
 
 @contextmanager
 def config(npu):
-    topo = SaiPtfTopologyFixture()
-    topo.setup(npu)
+    topo = SaiPtfTopologyFixture(npu)
+    topo.setup()
     try:
         yield topo
     finally:
         topo.teardown()
+
+
+@pytest.fixture(scope="module")
+def topology(npu):
+    return SaiPtfTopologyFixture(npu)

--- a/topologies/sai_ptf_topology.py
+++ b/topologies/sai_ptf_topology.py
@@ -96,7 +96,7 @@ class SaiPtfTopologyMixin:
     default_vlan_id: str
     default_1q_bridge: str
 
-    def setup_ptf_topology(self, npu: Any) -> None:
+    def setup(self, npu: Any) -> None:
         """Initialize NPU reference, build aliases and bring up the full topology."""
         self.npu = npu
         self.def_bridge_port_list = []
@@ -125,7 +125,7 @@ class SaiPtfTopologyMixin:
         self.remove_default_bridge_ports()
         self.create_sai_helper_topology()
 
-    def teardown_ptf_topology(self) -> None:
+    def teardown(self) -> None:
         """Tear down topology in the correct SAI order and restore default VLAN state."""
         self.npu.set(self.port2, ["SAI_PORT_ATTR_PORT_VLAN_ID", "0"])
         self.npu.set(self.lag1, ["SAI_LAG_ATTR_PORT_VLAN_ID", "0"])
@@ -422,8 +422,8 @@ class SaiPtfTopologyFixture(SaiPtfTopologyMixin):
 @contextmanager
 def config(npu):
     topo = SaiPtfTopologyFixture()
-    topo.setup_ptf_topology(npu)
+    topo.setup(npu)
     try:
         yield topo
     finally:
-        topo.teardown_ptf_topology()
+        topo.teardown()


### PR DESCRIPTION
## Summary
This PR simplifies the PTF topology lifecycle and recovery management in test_fdb.py by refactoring the state management directly into the npu object and native Pytest fixtures.

## Features:
- Introduced topology and register_topology fixtures (scope="module") to bind SaiPtfTopologyFixture directly to the npu instance (npu._topo).
- Replaced class-level custom flags with npu._topo_initialized to manage initialization state directly on the NPU object.

## How It Works
* Normal execution: 

1. At module start, register_topology attaches SaiPtfTopologyFixture to npu._topo, sets npu._topo_initialized = False, and runs npu._topo.setup(npu).
2. During setup_class_topology, the first test detects npu._topo_initialized == False, applies class-specific configurations (e.g., VLANs, FDB entries), and marks npu._topo_initialized = True.
3. Subsequent passing tests in the class see npu._topo_initialized == True and immediately return, safely reusing the configured topology without redundant setup overhead.

* On failure (`prev_test_failed`): 

The on_prev_test_failure fixture intercepts the failed state via prev_test_failed.

1. It invokes npu.reset(), clearing internal object registries, client states.
2. It invalidates the initialization state by setting npu._topo_initialized = False.
3. It immediately executes npu._topo.setup(npu) to rebuild a fresh, isolated base topology.
4. The next test sees npu._topo_initialized == False and re-runs setup_class_topology, re-applying class attributes on a clean NPU state.

* Teardown: Once all tests in the module complete, the yield block in register_topology executes npu._topo.teardown(), destroying remaining topology objects in SAI order and leaving the hardware in a clean state.