### PR TITLE
Add IPMC entry key helper to SaiNpu

### DIFF
--- a/common/sai_npu.py
+++ b/common/sai_npu.py
@@ -326,7 +326,7 @@ class SaiNpu(Sai):
             }
         )
 
-    def _ipmc_entry_key(self, vr_oid, src_ip, dst_ip, entry_type=0):
+    def ipmc_entry_key(self, vr_oid, src_ip, dst_ip, entry_type=0):
         return "SAI_OBJECT_TYPE_IPMC_ENTRY:" + json.dumps(
             {
                 "switch_id": self.switch_oid,

--- a/common/sai_npu.py
+++ b/common/sai_npu.py
@@ -326,6 +326,17 @@ class SaiNpu(Sai):
             }
         )
 
+    def _ipmc_entry_key(self, vr_oid, src_ip, dst_ip, entry_type=0):
+        return "SAI_OBJECT_TYPE_IPMC_ENTRY:" + json.dumps(
+            {
+                "switch_id": self.switch_oid,
+                "vr_id": vr_oid,
+                "type": str(entry_type),
+                "destination": dst_ip,
+                "source": src_ip,
+            }
+        )
+
     def fdb_entry_key(self, vlan_oid, mac):
         return "SAI_OBJECT_TYPE_FDB_ENTRY:" + json.dumps(
             {


### PR DESCRIPTION
## Summary

Add `SaiNpu.ipmc_entry_key()` for building IPv4 and IPv6 IPMC entry keys.

## Usage

```
ipmc_entry = npu.ipmc_entry_key(
    vr_oid,
    "10.10.10.1",
    "225.0.0.1",
)
npu.create(ipmc_entry, attrs)
```