### PR TITLE
Add shared FDB entry key helper

### DIFF
--- a/common/sai_npu.py
+++ b/common/sai_npu.py
@@ -147,7 +147,7 @@ class SaiNpu(Sai):
 
     def create_fdb(self, vlan_oid, mac, bp_oid, entry_type="SAI_FDB_ENTRY_TYPE_STATIC", action="SAI_PACKET_ACTION_FORWARD", do_assert=True):
         return self.create(
-                   self._fdb_entry_key(vlan_oid, mac),
+                   self.fdb_entry_key(vlan_oid, mac),
                    [
                        "SAI_FDB_ENTRY_ATTR_TYPE",           entry_type,
                        "SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", bp_oid,
@@ -156,7 +156,7 @@ class SaiNpu(Sai):
                    do_assert)
 
     def remove_fdb(self, vlan_oid, mac, do_assert=True):
-        return self.remove(self._fdb_entry_key(vlan_oid, mac), do_assert)
+        return self.remove(self.fdb_entry_key(vlan_oid, mac), do_assert)
 
     def create_vlan_member(self, vlan_oid, bp_oid, tagging_mode):
         oid = self.create(SaiObjType.VLAN_MEMBER,
@@ -326,7 +326,7 @@ class SaiNpu(Sai):
             }
         )
 
-    def _fdb_entry_key(self, vlan_oid, mac):
+    def fdb_entry_key(self, vlan_oid, mac):
         return "SAI_OBJECT_TYPE_FDB_ENTRY:" + json.dumps(
             {
                 "bvid": vlan_oid,

--- a/common/sai_npu.py
+++ b/common/sai_npu.py
@@ -147,13 +147,7 @@ class SaiNpu(Sai):
 
     def create_fdb(self, vlan_oid, mac, bp_oid, entry_type="SAI_FDB_ENTRY_TYPE_STATIC", action="SAI_PACKET_ACTION_FORWARD", do_assert=True):
         return self.create(
-                   'SAI_OBJECT_TYPE_FDB_ENTRY:' + json.dumps(
-                       {
-                           "bvid"      : vlan_oid,
-                           "mac"       : mac,
-                           "switch_id" : self.switch_oid
-                       }
-                   ),
+                   self._fdb_entry_key(vlan_oid, mac),
                    [
                        "SAI_FDB_ENTRY_ATTR_TYPE",           entry_type,
                        "SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", bp_oid,
@@ -162,13 +156,7 @@ class SaiNpu(Sai):
                    do_assert)
 
     def remove_fdb(self, vlan_oid, mac, do_assert=True):
-        return self.remove('SAI_OBJECT_TYPE_FDB_ENTRY:' + json.dumps(
-                       {
-                           "bvid"      : vlan_oid,
-                           "mac"       : mac,
-                           "switch_id" : self.switch_oid
-                       }),
-                    do_assert)
+        return self.remove(self._fdb_entry_key(vlan_oid, mac), do_assert)
 
     def create_vlan_member(self, vlan_oid, bp_oid, tagging_mode):
         oid = self.create(SaiObjType.VLAN_MEMBER,
@@ -335,5 +323,14 @@ class SaiNpu(Sai):
                 "ip_address": ip,
                 "rif_id": rif_oid,
                 "switch_id": npu.switch_oid,
+            }
+        )
+
+    def _fdb_entry_key(self, vlan_oid, mac):
+        return "SAI_OBJECT_TYPE_FDB_ENTRY:" + json.dumps(
+            {
+                "bvid": vlan_oid,
+                "mac": mac,
+                "switch_id": self.switch_oid,
             }
         )

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -1,4 +1,3 @@
-import json
 import time
 
 import pytest
@@ -36,17 +35,6 @@ def on_prev_test_failure(prev_test_failed, npu):
         npu.reset()
         npu._topo_initialized = False
         npu._topo.setup()
-
-
-def _fdb_entry_key(npu, vlan_oid, mac):
-    return "SAI_OBJECT_TYPE_FDB_ENTRY:" + json.dumps(
-        {
-            "bvid": vlan_oid,
-            "mac": mac,
-            "switch_id": npu.switch_oid,
-        }
-    )
-
 
 def _sai_wait_fdb_age(timeout_sec):
     """Match sai_base_test.SaiHelper.saiWaitFdbAge (sleep timeout + 10s buffer)."""
@@ -225,7 +213,7 @@ class TestFdbAttribute:
         3. Set SAI_FDB_ENTRY_ATTR_PACKET_ACTION to SAI_PACKET_ACTION_FORWARD
         4. Get SAI_FDB_ENTRY_ATTR_PACKET_ACTION and verify it is SAI_PACKET_ACTION_FORWARD
         """
-        fdb_key = _fdb_entry_key(npu, self.vlan_oid, self.mac)
+        fdb_key = npu._fdb_entry_key(self.vlan_oid, self.mac)
 
         status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
         assert status == "SAI_STATUS_SUCCESS"
@@ -1084,7 +1072,7 @@ class TestFdbMacMove:
         """
         if not npu.run_traffic:
             pytest.skip("Traffic generation disabled")
-        moving_key = _fdb_entry_key(npu, self.vlan_oid, self.moving_mac)
+        moving_key = npu._fdb_entry_key(self.vlan_oid, self.moving_mac)
         pkt = simple_udp_packet(eth_dst=self.chck_mac, eth_src=self.moving_mac)
         chck_pkt = simple_udp_packet(eth_dst=self.moving_mac, eth_src=self.chck_mac)
         port_chain = [self.dev_port0, self.dev_port1, self.dev_port5, self.dev_port27, self.dev_port1]
@@ -1124,7 +1112,7 @@ class TestFdbMacMove:
         """
         if not npu.run_traffic:
             pytest.skip("Traffic generation disabled")
-        fdb_key = _fdb_entry_key(npu, self.vlan_oid, self.moving_mac)
+        fdb_key = npu._fdb_entry_key(npu, self.vlan_oid, self.moving_mac)
         port_chain = [self.dev_port0, self.dev_port1, self.dev_port5, self.dev_port27, self.dev_port1]
         bport_chain = [self.port0_bp, self.port1_bp, self.lag1_bp, self.lag10_bp, self.port1_bp]
         chck_pkt = simple_udp_packet(eth_dst=self.moving_mac, eth_src=self.chck_mac)
@@ -3091,7 +3079,7 @@ class TestFdbEvent:
             send_packet(dataplane, 0, pkt)
             verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[1], [4, 5, 6]])
             time.sleep(2)
-            fdb_key = _fdb_entry_key(npu, self.vlan_oid, self.src_mac)
+            fdb_key = npu._fdb_entry_key(self.vlan_oid, self.src_mac)
             status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
             assert status == "SAI_STATUS_SUCCESS"
             assert data.oid() == self.port0_bp
@@ -3126,7 +3114,7 @@ class TestFdbEvent:
             send_packet(dataplane, 0, pkt)
             verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[1], [4, 5, 6]])
             time.sleep(2)
-            fdb_key = _fdb_entry_key(npu, self.vlan_oid, self.src_mac)
+            fdb_key = npu._fdb_entry_key(self.vlan_oid, self.src_mac)
             status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
             assert status == "SAI_STATUS_SUCCESS"
             assert data.oid() == self.port0_bp
@@ -3165,7 +3153,7 @@ class TestFdbEvent:
             send_packet(dataplane, 0, pkt)
             verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[1], [4, 5, 6]])
             time.sleep(2)
-            fdb_key = _fdb_entry_key(npu, self.vlan_oid, self.src_mac)
+            fdb_key = npu._fdb_entry_key(self.vlan_oid, self.src_mac)
             status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
             assert status == "SAI_STATUS_SUCCESS"
             assert data.oid() == self.port0_bp
@@ -3211,7 +3199,7 @@ class TestFdbEvent:
             send_packet(dataplane, 0, pkt)
             verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[1], [4, 5, 6]])
             time.sleep(2)
-            fdb_key = _fdb_entry_key(npu, self.vlan_oid, self.src_mac)
+            fdb_key = npu._fdb_entry_key(self.vlan_oid, self.src_mac)
             status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
             assert status == "SAI_STATUS_SUCCESS"
             assert data.oid() == self.port0_bp
@@ -3254,7 +3242,7 @@ class TestFdbEvent:
             send_packet(dataplane, 0, pkt)
             verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[1], [4, 5, 6]])
             time.sleep(2)
-            fdb_key = _fdb_entry_key(npu, self.vlan_oid, self.src_mac)
+            fdb_key = npu._fdb_entry_key(self.vlan_oid, self.src_mac)
             status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
             assert status == "SAI_STATUS_SUCCESS"
             assert data.oid() == self.port0_bp

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -213,7 +213,7 @@ class TestFdbAttribute:
         3. Set SAI_FDB_ENTRY_ATTR_PACKET_ACTION to SAI_PACKET_ACTION_FORWARD
         4. Get SAI_FDB_ENTRY_ATTR_PACKET_ACTION and verify it is SAI_PACKET_ACTION_FORWARD
         """
-        fdb_key = npu._fdb_entry_key(self.vlan_oid, self.mac)
+        fdb_key = npu.fdb_entry_key(self.vlan_oid, self.mac)
 
         status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
         assert status == "SAI_STATUS_SUCCESS"
@@ -1072,7 +1072,7 @@ class TestFdbMacMove:
         """
         if not npu.run_traffic:
             pytest.skip("Traffic generation disabled")
-        moving_key = npu._fdb_entry_key(self.vlan_oid, self.moving_mac)
+        moving_key = npu.fdb_entry_key(self.vlan_oid, self.moving_mac)
         pkt = simple_udp_packet(eth_dst=self.chck_mac, eth_src=self.moving_mac)
         chck_pkt = simple_udp_packet(eth_dst=self.moving_mac, eth_src=self.chck_mac)
         port_chain = [self.dev_port0, self.dev_port1, self.dev_port5, self.dev_port27, self.dev_port1]
@@ -1112,7 +1112,7 @@ class TestFdbMacMove:
         """
         if not npu.run_traffic:
             pytest.skip("Traffic generation disabled")
-        fdb_key = npu._fdb_entry_key(npu, self.vlan_oid, self.moving_mac)
+        fdb_key = npu.fdb_entry_key(npu, self.vlan_oid, self.moving_mac)
         port_chain = [self.dev_port0, self.dev_port1, self.dev_port5, self.dev_port27, self.dev_port1]
         bport_chain = [self.port0_bp, self.port1_bp, self.lag1_bp, self.lag10_bp, self.port1_bp]
         chck_pkt = simple_udp_packet(eth_dst=self.moving_mac, eth_src=self.chck_mac)
@@ -3079,7 +3079,7 @@ class TestFdbEvent:
             send_packet(dataplane, 0, pkt)
             verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[1], [4, 5, 6]])
             time.sleep(2)
-            fdb_key = npu._fdb_entry_key(self.vlan_oid, self.src_mac)
+            fdb_key = npu.fdb_entry_key(self.vlan_oid, self.src_mac)
             status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
             assert status == "SAI_STATUS_SUCCESS"
             assert data.oid() == self.port0_bp
@@ -3114,7 +3114,7 @@ class TestFdbEvent:
             send_packet(dataplane, 0, pkt)
             verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[1], [4, 5, 6]])
             time.sleep(2)
-            fdb_key = npu._fdb_entry_key(self.vlan_oid, self.src_mac)
+            fdb_key = npu.fdb_entry_key(self.vlan_oid, self.src_mac)
             status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
             assert status == "SAI_STATUS_SUCCESS"
             assert data.oid() == self.port0_bp
@@ -3153,7 +3153,7 @@ class TestFdbEvent:
             send_packet(dataplane, 0, pkt)
             verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[1], [4, 5, 6]])
             time.sleep(2)
-            fdb_key = npu._fdb_entry_key(self.vlan_oid, self.src_mac)
+            fdb_key = npu.fdb_entry_key(self.vlan_oid, self.src_mac)
             status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
             assert status == "SAI_STATUS_SUCCESS"
             assert data.oid() == self.port0_bp
@@ -3199,7 +3199,7 @@ class TestFdbEvent:
             send_packet(dataplane, 0, pkt)
             verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[1], [4, 5, 6]])
             time.sleep(2)
-            fdb_key = npu._fdb_entry_key(self.vlan_oid, self.src_mac)
+            fdb_key = npu.fdb_entry_key(self.vlan_oid, self.src_mac)
             status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
             assert status == "SAI_STATUS_SUCCESS"
             assert data.oid() == self.port0_bp
@@ -3242,7 +3242,7 @@ class TestFdbEvent:
             send_packet(dataplane, 0, pkt)
             verify_each_packet_on_multiple_port_lists(dataplane, [tag_pkt, pkt], [[1], [4, 5, 6]])
             time.sleep(2)
-            fdb_key = npu._fdb_entry_key(self.vlan_oid, self.src_mac)
+            fdb_key = npu.fdb_entry_key(self.vlan_oid, self.src_mac)
             status, data = npu.get(fdb_key, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", "oid:0x0"], False)
             assert status == "SAI_STATUS_SUCCESS"
             assert data.oid() == self.port0_bp


### PR DESCRIPTION
## Summary
Add `SaiNpu.fdb_entry_key()` and reuse it across FDB tests.



