### PR TITLE
 Add license to native tests

### DIFF
--- a/tests/native/test_fdb.py
+++ b/tests/native/test_fdb.py
@@ -1,3 +1,17 @@
+# Copyright 2021-present Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import time
 
 import pytest

--- a/tests/native/test_route.py
+++ b/tests/native/test_route.py
@@ -1,3 +1,17 @@
+# Copyright 2021-present Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import time
 from urllib import request

--- a/tests/native/test_vlan.py
+++ b/tests/native/test_vlan.py
@@ -1,3 +1,17 @@
+#  Copyright 2021-present Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import time
 
 import pytest


### PR DESCRIPTION
## Summary

Add the Apache License 2.0 copyright header to native SAI  tests:

- `test_fdb.py`
- `test_vlan.py`
- `test_route.py`