### PR TITLE
Add support for retrieving object availability

### DIFF
--- a/.github/workflows/sc-client-server-deb11.yml
+++ b/.github/workflows/sc-client-server-deb11.yml
@@ -177,6 +177,8 @@ jobs:
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v -k "test_flex_counters"
     - name: Run warm reboot test cases
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_warm_reboot.py
+    - name: Run get availability test cases
+      run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_get_availability.py
     - name: Run unit tests
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v ut/test_acl_ut.py ut/test_bridge_ut.py ut/test_vrf_ut.py ut/test_port_ut.py ut/test_fdb_ut.py ut/test_lag_ut.py
     - name: Run unit tests

--- a/.github/workflows/sc-client-server-deb12.yml
+++ b/.github/workflows/sc-client-server-deb12.yml
@@ -179,6 +179,8 @@ jobs:
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v -k "test_flex_counters"
     - name: Run warm reboot test cases
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_warm_reboot.py
+    - name: Run get availability test cases
+      run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_get_availability.py
     - name: Run unit tests
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v ut/test_acl_ut.py ut/test_bridge_ut.py ut/test_vrf_ut.py ut/test_port_ut.py ut/test_fdb_ut.py ut/test_lag_ut.py
     - name: Run unit tests

--- a/.github/workflows/sc-client-server-deb13.yml
+++ b/.github/workflows/sc-client-server-deb13.yml
@@ -179,6 +179,8 @@ jobs:
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v -k "test_flex_counters"
     - name: Run warm reboot test cases
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_warm_reboot.py
+    - name: Run get availability test cases
+      run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v test_get_availability.py
     - name: Run unit tests
       run: ./exec.sh --no-tty -i client pytest --testbed=saivs_client_server -v ut/test_acl_ut.py ut/test_bridge_ut.py ut/test_vrf_ut.py ut/test_port_ut.py ut/test_fdb_ut.py ut/test_lag_ut.py
     - name: Run unit tests

--- a/.github/workflows/sc-standalone-deb11.yml
+++ b/.github/workflows/sc-standalone-deb11.yml
@@ -78,6 +78,8 @@ jobs:
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_flex_counters"
     - name: Run warm reboot test cases
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_warm_reboot.py
+    - name: Run get availability test cases
+      run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_get_availability.py
     - name: Run sairedis tests
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_sairec"
     - name: Run unit tests
@@ -107,6 +109,8 @@ jobs:
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v -k "test_flex_counters"
     - name: Run thrift warm reboot test cases
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_warm_reboot.py
+    - name: Run thrift get availability test cases
+      run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_get_availability.py
     - name: Run thrift data-driven tests
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_l2_basic_dd.py
     - name: Run thrift unit tests

--- a/.github/workflows/sc-standalone-deb12.yml
+++ b/.github/workflows/sc-standalone-deb12.yml
@@ -78,6 +78,8 @@ jobs:
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_flex_counters"
     - name: Run warm reboot test cases
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_warm_reboot.py
+    - name: Run get availability test cases
+      run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_get_availability.py
     - name: Run sairedis tests
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_sairec"
     - name: Run unit tests
@@ -107,6 +109,8 @@ jobs:
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v -k "test_flex_counters"
     - name: Run thrift warm reboot test cases
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_warm_reboot.py
+    - name: Run thrift get availability test cases
+      run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_get_availability.py
     - name: Run thrift data-driven tests
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_l2_basic_dd.py
     - name: Run thrift unit tests

--- a/.github/workflows/sc-standalone-deb13.yml
+++ b/.github/workflows/sc-standalone-deb13.yml
@@ -78,6 +78,8 @@ jobs:
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_flex_counters"
     - name: Run warm reboot test cases
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_warm_reboot.py
+    - name: Run get availability test cases
+      run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v test_get_availability.py
     - name: Run sairedis tests
       run: ./exec.sh --no-tty pytest --testbed=saivs_standalone -v -k "test_sairec"
     - name: Run unit tests
@@ -107,6 +109,8 @@ jobs:
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v -k "test_flex_counters"
     - name: Run thrift warm reboot test cases
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_warm_reboot.py
+    - name: Run thrift get availability test cases
+      run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_get_availability.py
     - name: Run thrift data-driven tests
       run: ./exec.sh --no-tty -s thrift pytest --testbed=saivs_thrift_standalone -v test_l2_basic_dd.py
     - name: Run thrift unit tests

--- a/common/sai.py
+++ b/common/sai.py
@@ -351,13 +351,12 @@ class Sai():
         self.sai_client.warm_shutdown(tout=warm_tout)
         self.sai_client.verify_restore_after_warm_shutdown(tout=after_warm_tout)
     
+    def get_availability(self, switch_oid, object_type, attrs=None, do_assert=True):
+        return self.sai_client.get_availability(switch_oid, object_type, attrs, do_assert)
+
     # Flush FDB
     def flush_fdb_entries(self, obj, attrs=None):
         self.sai_client.flush_fdb_entries(obj, attrs)
-
-    # Get availability
-    def get_availability(self, obj, attrs=[], do_assert=True):
-        return self.sai_client.get_availability(obj, attrs)
 
     # Host interface
     def remote_iface_exists(self, iface):

--- a/common/sai.py
+++ b/common/sai.py
@@ -355,6 +355,10 @@ class Sai():
     def flush_fdb_entries(self, obj, attrs=None):
         self.sai_client.flush_fdb_entries(obj, attrs)
 
+    # Get availability
+    def get_availability(self, obj, attrs=[], do_assert=True):
+        return self.sai_client.get_availability(obj, attrs)
+
     # Host interface
     def remote_iface_exists(self, iface):
         return self.sai_client.remote_iface_exists(iface)

--- a/common/sai_client/sai_client.py
+++ b/common/sai_client/sai_client.py
@@ -85,6 +85,10 @@ class SaiClient:
     def verify_restore_after_warm_shutdown(self, tout=5):
         raise NotImplementedError
 
+    # Get availability
+    def get_availability(self, obj, attrs, do_assert=True):
+        raise NotImplementedError
+
     # Flush FDB
     def flush_fdb_entries(self, obj, attrs=None):
         raise NotImplementedError

--- a/common/sai_client/sai_client.py
+++ b/common/sai_client/sai_client.py
@@ -85,8 +85,7 @@ class SaiClient:
     def verify_restore_after_warm_shutdown(self, tout=5):
         raise NotImplementedError
 
-    # Get availability
-    def get_availability(self, obj, attrs, do_assert=True):
+    def get_availability(self, switch_oid, object_type, attrs, do_assert=True):
         raise NotImplementedError
 
     # Flush FDB

--- a/common/sai_client/sai_redis_client/sai_redis_client.py
+++ b/common/sai_client/sai_redis_client/sai_redis_client.py
@@ -632,7 +632,11 @@ class SaiRedisClient(SaiClient):
         if do_assert:
             assert status[2] == 'SAI_STATUS_SUCCESS', f"get_availability({switch_oid}, {attrs}) --> {status}"
 
-        data = SaiData(status[1].decode("utf-8")).uint32()
+        if status[2] == 'SAI_STATUS_SUCCESS':
+            data = SaiData(status[1].decode("utf-8")).uint32()
+        else:
+            data = None
+
         if do_assert:
             return data
 

--- a/common/sai_client/sai_redis_client/sai_redis_client.py
+++ b/common/sai_client/sai_redis_client/sai_redis_client.py
@@ -617,29 +617,26 @@ class SaiRedisClient(SaiClient):
         # syncd is running, but it may have not restored state before warm-shutdown
         time.sleep(tout)
 
-    def get_availability(self, obj, attrs, do_assert=True):
-        import pdb; pdb.set_trace()
-        assert obj.startswith("oid:")
+    def get_availability(self, switch_oid, object_type, attrs, do_assert=True):
+        assert switch_oid.startswith("oid:")
+        assert self.vid_to_type(switch_oid) == "SAI_OBJECT_TYPE_SWITCH", f"Invalid switch OID {switch_oid}"
 
-        if type(attrs) != str:
-            attrs = json.dumps(attrs)
-        status = self.operate(obj, attrs, "Sobject_type_get_availability_query")
+        if attrs is None:
+            attrs = []
+        attrs.extend(["SAI_OBJECT_TYPE", object_type])
+        attrs = json.dumps(attrs)
+
+        status = self.operate(switch_oid, attrs, "Sobject_type_get_availability_query")
         status[2] = status[2].decode("utf-8")
         
         if do_assert:
-            assert status[2] == 'SAI_STATUS_SUCCESS', f"get_availability({obj}, {attrs}) --> {status}"
+            assert status[2] == 'SAI_STATUS_SUCCESS', f"get_availability({switch_oid}, {attrs}) --> {status}"
 
-        data = SaiData(status[1].decode("utf-8"))
-        # raw = status[1].decode("utf-8")
-        # if raw.startswith("COUNT="):
-        #     raw = json.dumps(["COUNT", raw.split("=", 1)[1]])
-        # data = SaiData(raw)
+        data = SaiData(status[1].decode("utf-8")).uint32()
         if do_assert:
             return data
 
         return status[2], data
-
-
 
     def flush_fdb_entries(self, obj, attrs=None):
         """

--- a/common/sai_client/sai_redis_client/sai_redis_client.py
+++ b/common/sai_client/sai_redis_client/sai_redis_client.py
@@ -617,6 +617,29 @@ class SaiRedisClient(SaiClient):
         # syncd is running, but it may have not restored state before warm-shutdown
         time.sleep(tout)
 
+    def get_availability(self, obj, attrs, do_assert=True):
+        import pdb; pdb.set_trace()
+        assert obj.startswith("oid:")
+
+        if type(attrs) != str:
+            attrs = json.dumps(attrs)
+        status = self.operate(obj, attrs, "Sobject_type_get_availability_query")
+        status[2] = status[2].decode("utf-8")
+        
+        if do_assert:
+            assert status[2] == 'SAI_STATUS_SUCCESS', f"get_availability({obj}, {attrs}) --> {status}"
+
+        data = SaiData(status[1].decode("utf-8"))
+        # raw = status[1].decode("utf-8")
+        # if raw.startswith("COUNT="):
+        #     raw = json.dumps(["COUNT", raw.split("=", 1)[1]])
+        # data = SaiData(raw)
+        if do_assert:
+            return data
+
+        return status[2], data
+
+
 
     def flush_fdb_entries(self, obj, attrs=None):
         """

--- a/tests/test_get_availability.py
+++ b/tests/test_get_availability.py
@@ -1,0 +1,105 @@
+import pytest
+from saichallenger.common.sai_data import SaiObjType
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_all(testbed_instance):
+    testbed = testbed_instance
+    if testbed is not None and len(testbed.npu) != 1:
+        pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
+
+@pytest.fixture(autouse=True)
+def on_prev_test_failure(prev_test_failed, npu):
+    if prev_test_failed:
+        npu.reset()
+
+
+def _create_port_rif(npu, port_idx=0):
+    npu.remove_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[port_idx])
+    npu.remove(npu.dot1q_bp_oids[port_idx])
+    return npu.create(
+        SaiObjType.ROUTER_INTERFACE,
+        [
+            "SAI_ROUTER_INTERFACE_ATTR_TYPE", "SAI_ROUTER_INTERFACE_TYPE_PORT",
+            "SAI_ROUTER_INTERFACE_ATTR_PORT_ID", npu.port_oids[port_idx],
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID", npu.default_vrf_oid,
+        ],
+    )
+
+
+def _restore_port_l2(npu, port_idx=0):
+    bp_oid = npu.create(
+        SaiObjType.BRIDGE_PORT,
+        [
+            "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+            "SAI_BRIDGE_PORT_ATTR_PORT_ID", npu.port_oids[port_idx],
+            "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true",
+        ],
+    )
+    npu.dot1q_bp_oids[port_idx] = bp_oid
+    npu.create_vlan_member(npu.default_vlan_oid, bp_oid, "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+    npu.set(npu.port_oids[port_idx], ["SAI_PORT_ATTR_PORT_VLAN_ID", npu.default_vlan_id])
+
+
+def test_next_hop_get_availability(npu):
+    """
+    Description:
+    Get next-hop object availability, create a next hop, and verify availability decreases.
+
+    Test scenario:
+    1. Get next-hop availability with no extra attributes
+    2. Create a next-hop object
+    3. Get availability again and verify it decreased
+    4. Clean up configuration
+    """
+    nhop_ip = "10.10.10.10"
+    dst_mac = "00:99:99:99:99:99"
+    rif = _create_port_rif(npu)
+    neighbor_key = npu._neighbor_entry_key(rif, nhop_ip)
+    npu.create(neighbor_key, ["SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS", dst_mac])
+    nhop = None
+    try:
+        before = int(npu.get_availability("SAI_OBJECT_TYPE_NEXT_HOP:" + npu.switch_oid).value())
+        nhop = npu.create(
+            SaiObjType.NEXT_HOP,
+            [
+                "SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP",
+                "SAI_NEXT_HOP_ATTR_IP", nhop_ip,
+                "SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID", rif,
+            ],
+        )
+        after = int(npu.get_availability("SAI_OBJECT_TYPE_NEXT_HOP:" + npu.switch_oid).value())
+        assert after == before - 1
+    finally:
+        if nhop:
+            npu.remove(nhop)
+        npu.remove(neighbor_key)
+        npu.remove(rif)
+        _restore_port_l2(npu)
+
+
+def test_neighbor_get_availability(npu):
+    """
+    Description:
+    Get neighbor entry availability, create a neighbor, and verify availability decreases.
+
+    Test scenario:
+    1. Get neighbor entry availability with no extra attributes
+    2. Create a neighbor entry
+    3. Get availability again and verify it decreased
+    4. Clean up configuration
+    """
+    ipv4_addr = "10.10.10.1"
+    mac_addr = "00:10:10:10:10:10"
+    rif = _create_port_rif(npu)
+    neighbor_key = npu._neighbor_entry_key(rif, ipv4_addr)
+    try:
+        before =  npu.get_availability(npu.switch_oid, ["OBJECT_TYPE","SAI_OBJECT_TYPE_NEIGHBOR_ENTRY"])
+        print(before)
+        npu.create(neighbor_key, ["SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS", mac_addr])
+        after = int(npu.get_availability("SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:" + npu.switch_oid).value())
+        assert after == before - 1
+    finally:
+        npu.remove(neighbor_key)
+        npu.remove(rif)
+        _restore_port_l2(npu)

--- a/tests/test_get_availability.py
+++ b/tests/test_get_availability.py
@@ -54,29 +54,31 @@ def test_next_hop_get_availability(npu):
     """
     nhop_ip = "10.10.10.10"
     dst_mac = "00:99:99:99:99:99"
+
+    status, before = npu.get_availability(npu.switch_oid, "SAI_OBJECT_TYPE_NEXT_HOP", do_assert=False)
+    if (status == "SAI_STATUS_NOT_SUPPORTED"):
+        pytest.skip("SAI_OBJECT_TYPE_NEXT_HOP availability is not supported")
+    assert status == "SAI_STATUS_SUCCESS"
+
     rif = _create_port_rif(npu)
     neighbor_key = npu._neighbor_entry_key(rif, nhop_ip)
     npu.create(neighbor_key, ["SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS", dst_mac])
-    nhop = None
-    try:
-        before = int(npu.get_availability("SAI_OBJECT_TYPE_NEXT_HOP:" + npu.switch_oid).value())
-        nhop = npu.create(
-            SaiObjType.NEXT_HOP,
-            [
-                "SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP",
-                "SAI_NEXT_HOP_ATTR_IP", nhop_ip,
-                "SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID", rif,
-            ],
-        )
-        after = int(npu.get_availability("SAI_OBJECT_TYPE_NEXT_HOP:" + npu.switch_oid).value())
-        assert after == before - 1
-    finally:
-        if nhop:
-            npu.remove(nhop)
-        npu.remove(neighbor_key)
-        npu.remove(rif)
-        _restore_port_l2(npu)
+    nhop = npu.create(
+        SaiObjType.NEXT_HOP,
+        [
+            "SAI_NEXT_HOP_ATTR_TYPE", "SAI_NEXT_HOP_TYPE_IP",
+            "SAI_NEXT_HOP_ATTR_IP", nhop_ip,
+            "SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID", rif,
+        ],
+    )
 
+    after = npu.get_availability(npu.switch_oid, "SAI_OBJECT_TYPE_NEXT_HOP")
+    assert after == before - 1
+
+    npu.remove(nhop)
+    npu.remove(neighbor_key)
+    npu.remove(rif)
+    _restore_port_l2(npu)
 
 def test_neighbor_get_availability(npu):
     """
@@ -84,22 +86,29 @@ def test_neighbor_get_availability(npu):
     Get neighbor entry availability, create a neighbor, and verify availability decreases.
 
     Test scenario:
-    1. Get neighbor entry availability with no extra attributes
-    2. Create a neighbor entry
+    1. Get neighbor entry availability with IPV4 address family
+    2. Create a neighbor entry with IPV4 address family
     3. Get availability again and verify it decreased
     4. Clean up configuration
     """
     ipv4_addr = "10.10.10.1"
     mac_addr = "00:10:10:10:10:10"
+
+    status, before = npu.get_availability(npu.switch_oid, "SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", 
+                                          ["SAI_NEIGHBOR_ENTRY_ATTR_IP_ADDR_FAMILY","SAI_IP_ADDR_FAMILY_IPV4"], 
+                                          do_assert=False)
+    if (status == "SAI_STATUS_NOT_SUPPORTED"):
+        pytest.skip("SAI_OBJECT_TYPE_NEIGHBOR_ENTRY availability is not supported")
+    assert status == "SAI_STATUS_SUCCESS"
+    
     rif = _create_port_rif(npu)
     neighbor_key = npu._neighbor_entry_key(rif, ipv4_addr)
-    try:
-        before =  npu.get_availability(npu.switch_oid, ["OBJECT_TYPE","SAI_OBJECT_TYPE_NEIGHBOR_ENTRY"])
-        print(before)
-        npu.create(neighbor_key, ["SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS", mac_addr])
-        after = int(npu.get_availability("SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:" + npu.switch_oid).value())
-        assert after == before - 1
-    finally:
-        npu.remove(neighbor_key)
-        npu.remove(rif)
-        _restore_port_l2(npu)
+    npu.create(neighbor_key, ["SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS", mac_addr])
+
+    after = npu.get_availability(npu.switch_oid, "SAI_OBJECT_TYPE_NEIGHBOR_ENTRY",
+                                 ["SAI_NEIGHBOR_ENTRY_ATTR_IP_ADDR_FAMILY","SAI_IP_ADDR_FAMILY_IPV4"])
+    assert after == before - 1
+
+    npu.remove(neighbor_key)
+    npu.remove(rif)
+    _restore_port_l2(npu)

--- a/tests/test_get_availability.py
+++ b/tests/test_get_availability.py
@@ -1,12 +1,16 @@
 import pytest
 from saichallenger.common.sai_data import SaiObjType
+from sai_client.sai_redis_client.sai_redis_client import SaiRedisClient
 
 
 @pytest.fixture(scope="module", autouse=True)
-def skip_all(testbed_instance):
+def skip_all(testbed_instance, npu):
     testbed = testbed_instance
     if testbed is not None and len(testbed.npu) != 1:
         pytest.skip("invalid for \"{}\" testbed".format(testbed.name))
+    
+    if not isinstance(npu.sai_client, SaiRedisClient):
+        pytest.skip("Get availability logic is not implemented for non-redis SAI client")
 
 @pytest.fixture(autouse=True)
 def on_prev_test_failure(prev_test_failed, npu):


### PR DESCRIPTION
Add support for retrieving object availability in Sai base class. Add new test to verify behaviour, add new test to the CI

## Test
```sh
./exec.sh -t saivs pytest --testbed=saivs_standalone -v test_get_availability.py
```

## Test result
```sh
./exec.sh -t saivs pytest --testbed=saivs_standalone -v test_get_availability.py
test_get_availability.py::test_next_hop_get_availability SKIPPED (SAI_OBJECT_TYPE_NEXT_HOP availability is not supported)                                                 [ 50%]
test_get_availability.py::test_neighbor_get_availability SKIPPED (SAI_OBJECT_TYPE_NEIGHBOR_ENTRY availability is not supported)                                           [100%]

============================================================================== 2 skipped in 7.62s ===============================================================================
```