### PR TITLE
Correct bridge port removal process

### DIFF
--- a/common/sai_npu.py
+++ b/common/sai_npu.py
@@ -182,7 +182,7 @@ class SaiNpu(Sai):
 
     def remove_bridge_port(self, bp_oid):
         self.set(bp_oid, ["SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "false"])
-        self.flush_fdb_entries(bp_oid, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", bp_oid])
+        self.flush_fdb_entries(self.switch_oid, ["SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID", bp_oid])
         self.remove(bp_oid)
 
     def _route_entry_key(self, vr_oid, prefix):

--- a/common/sai_npu.py
+++ b/common/sai_npu.py
@@ -181,8 +181,19 @@ class SaiNpu(Sai):
         self.remove(vlan_mbr_oid)
 
     def remove_bridge_port(self, bp_oid):
+        """Remove a bridge port using the SAI-required teardown sequence.
+
+        Per the SAI comment on SAI_BRIDGE_PORT_ATTR_ADMIN_STATE:
+            Before removing a bridge port, need to disable it by setting admin mode 
+            to false, then flush the FDB entries, and then remove it.
+
+        This helper flushes only dynamic FDB entries for the given bridge port.
+        Static entries must be deleted by the caller beforehand.
+        """
         self.set(bp_oid, ["SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "false"])
-        self.flush_fdb_entries(self.switch_oid, ["SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID", bp_oid])
+        self.flush_fdb_entries(self.switch_oid, 
+                               ["SAI_FDB_FLUSH_ATTR_ENTRY_TYPE", "SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC",
+                                "SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID", bp_oid])
         self.remove(bp_oid)
 
     def _route_entry_key(self, vr_oid, prefix):

--- a/common/sai_npu.py
+++ b/common/sai_npu.py
@@ -180,6 +180,11 @@ class SaiNpu(Sai):
         assert vlan_mbr_oid, f"Bridge Port {bp_oid} is not a member of VLAN {vlan_oid}"
         self.remove(vlan_mbr_oid)
 
+    def remove_bridge_port(self, bp_oid):
+        self.set(bp_oid, ["SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "false"])
+        self.flush_fdb_entries(bp_oid, ["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID", bp_oid])
+        self.remove(bp_oid)
+
     def _route_entry_key(self, vr_oid, prefix):
         return "SAI_OBJECT_TYPE_ROUTE_ENTRY:" + json.dumps(
             {
@@ -242,7 +247,7 @@ class SaiNpu(Sai):
             oid =  self.get_vlan_member(self.default_vlan_oid, self.dot1q_bp_oids[idx])
             if oid:
                 self.remove(oid)
-            self.remove(self.dot1q_bp_oids[idx])
+            self.remove_bridge_port(self.dot1q_bp_oids[idx])
             status, data = self.get(self.port_oids[idx], ["SAI_PORT_ATTR_PORT_SERDES_ID"], do_assert=False)
             if status == "SAI_STATUS_SUCCESS" and data.oid() != "oid:0x0":
                 self.remove(data.oid())

--- a/tests/native/test_fdb.py
+++ b/tests/native/test_fdb.py
@@ -445,7 +445,7 @@ class TestFdbNoLearn:
         chck_pkt, tag_chck_pkt = self._reverse_pkt()
         port0_bp = self.port0_bp
         try:
-            npu.remove(port0_bp)
+            npu.remove_bridge_port(port0_bp)
             send_packet(dataplane, self.dev_port0, pkt)
             verify_packets(dataplane, tag_pkt, [self.dev_port1])
             verify_packet_any_port(dataplane, pkt, self.lag_ports)
@@ -752,7 +752,7 @@ class TestFdbLearn:
             if new_vlan_member_oid is not None:
                 npu.remove(new_vlan_member_oid)
             if new_vlan_bp is not None:
-                npu.remove(new_vlan_bp)
+                npu.remove_bridge_port(new_vlan_bp)
 
     def test_mac_learn_error(self, npu, dataplane):
         """
@@ -1029,11 +1029,11 @@ class TestFdbMacMove:
         npu.remove(request.cls._vlan10_member4)
         for lm in reversed(request.cls._lag10_members):
             npu.remove(lm)
-        npu.remove(request.cls._lag10_bp)
+        npu.remove_bridge_port(request.cls._lag10_bp)
         npu.remove(request.cls._lag10)
         npu.set(request.cls._port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", "0"])
         npu.remove(request.cls._vlan10_member3)
-        npu.remove(request.cls.port24_bp)
+        npu.remove_bridge_port(request.cls.port24_bp)
         npu.set(request.cls.port1, ["SAI_PORT_ATTR_PORT_VLAN_ID", "0"])
         npu.remove(request.cls._vlan10_member1_ut)
         new_member = npu.create_vlan_member(
@@ -1268,7 +1268,7 @@ class TestFdbFlush:
                 setattr(request.cls, _mbr_attr, None)
 
         if request.cls.port24_bp is not None:
-            npu.remove(request.cls.port24_bp)
+            npu.remove_bridge_port(request.cls.port24_bp)
 
         if request.cls._vlan10_member1_ut is not None:
             npu.set(request.cls.port1, ["SAI_PORT_ATTR_PORT_VLAN_ID", "0"])
@@ -2414,7 +2414,7 @@ class TestFdbAge:
             ],
         )
         npu.remove(request.cls._vlan10_member3)
-        npu.remove(request.cls._port24_bp)
+        npu.remove_bridge_port(request.cls._port24_bp)
         npu.set(request.cls._port24_oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", npu.default_vlan_id])
         npu.set(npu.switch_oid, ["SAI_SWITCH_ATTR_FDB_AGING_TIME", "0"])
         npu._topo_initialized = False
@@ -2744,9 +2744,9 @@ class TestFdbMiss:
         npu.remove(request.cls._vm1)
         npu.remove(request.cls._vm2)
         npu.remove(request.cls._vlan100)
-        npu.remove(request.cls._port24_bp)
-        npu.remove(request.cls._port25_bp)
-        npu.remove(request.cls._port26_bp)
+        npu.remove_bridge_port(request.cls._port24_bp)
+        npu.remove_bridge_port(request.cls._port25_bp)
+        npu.remove_bridge_port(request.cls._port26_bp)
         npu._topo_initialized = False
 
     def _restore_unicast_fwd(self, npu):

--- a/tests/native/test_route.py
+++ b/tests/native/test_route.py
@@ -486,7 +486,7 @@ class TestSviNeighbor:
                 npu.remove(vlan_member)
             npu.remove(vlan_oid)
             for bridge_port in reversed(bridge_ports):
-                npu.remove(bridge_port)
+                npu.remove_bridge_port(bridge_port)
 
 
 class TestCpuForward:
@@ -769,8 +769,8 @@ class L3DirBcastRouteTestHelper:
         npu.remove(request.cls.vlan100_member2)
         npu.remove(request.cls.vlan100_member1)
         npu.remove(request.cls.vlan100)
-        npu.remove(request.cls.port25_bp)
-        npu.remove(request.cls.port24_bp)
+        npu.remove_bridge_port(request.cls.port25_bp)
+        npu.remove_bridge_port(request.cls.port24_bp)
 
     def _verify_cpu_glean(self, dataplane, ingress_port, ip_dst, eth_src):
         pkt = simple_tcp_packet(

--- a/tests/native/test_vlan.py
+++ b/tests/native/test_vlan.py
@@ -301,8 +301,8 @@ class TestL2Vlan:
         npu.remove(request.cls.lag_mbr31)
         npu.remove(request.cls.lag_mbr41)
 
-        npu.remove(request.cls.lag10_bp)
-        npu.remove(request.cls.lag11_bp)
+        npu.remove_bridge_port(request.cls.lag10_bp)
+        npu.remove_bridge_port(request.cls.lag11_bp)
 
         npu.remove(request.cls.lag10)
         npu.remove(request.cls.lag11)
@@ -312,14 +312,14 @@ class TestL2Vlan:
         npu.remove(request.cls.vlan60)
         npu.remove(request.cls.vlan70)
 
-        npu.remove(request.cls.topo.port31_bp)
-        npu.remove(request.cls.topo.port30_bp)
-        npu.remove(request.cls.topo.port29_bp)
-        npu.remove(request.cls.topo.port28_bp)
-        npu.remove(request.cls.topo.port27_bp)
-        npu.remove(request.cls.topo.port26_bp)
-        npu.remove(request.cls.topo.port25_bp)
-        npu.remove(request.cls.topo.port24_bp)
+        npu.remove_bridge_port(request.cls.topo.port31_bp)
+        npu.remove_bridge_port(request.cls.topo.port30_bp)
+        npu.remove_bridge_port(request.cls.topo.port29_bp)
+        npu.remove_bridge_port(request.cls.topo.port28_bp)
+        npu.remove_bridge_port(request.cls.topo.port27_bp)
+        npu.remove_bridge_port(request.cls.topo.port26_bp)
+        npu.remove_bridge_port(request.cls.topo.port25_bp)
+        npu.remove_bridge_port(request.cls.topo.port24_bp)
         npu._topo_initialized = False
 
     def _inc_vlan10_ucast(self):
@@ -1649,7 +1649,7 @@ class TestL2Vlan:
             self.npu.set(self.npu.port_oids[31], ["SAI_PORT_ATTR_PORT_VLAN_ID", "1"])
             self.npu.remove(vlan_member3)
             vlan_member3 = None
-            self.npu.remove(port31_bp_local)
+            self.npu.remove_bridge_port(port31_bp_local)
             port31_bp_local = None
             self.npu.remove(prune_lag_mbr3)
             prune_lag_mbr3 = None
@@ -1666,7 +1666,7 @@ class TestL2Vlan:
             if vlan_member3 is not None:
                 self.npu.remove(vlan_member3)
             if port31_bp_local is not None:
-                self.npu.remove(port31_bp_local)
+                self.npu.remove_bridge_port(port31_bp_local)
 
             self.npu.set(prune_lag, ["SAI_LAG_ATTR_PORT_VLAN_ID", "1"])
             if prune_lag2 is not None:
@@ -1683,9 +1683,9 @@ class TestL2Vlan:
             if prune_lag_mbr4 is not None:
                 self.npu.remove(prune_lag_mbr4)
 
-            self.npu.remove(prune_lag_bp)
+            self.npu.remove_bridge_port(prune_lag_bp)
             if prune_lag2_bp is not None:
-                self.npu.remove(prune_lag2_bp)
+                self.npu.remove_bridge_port(prune_lag2_bp)
             self.npu.remove(prune_lag)
             if prune_lag2 is not None:
                 self.npu.remove(prune_lag2)

--- a/tests/test_l2_basic.py
+++ b/tests/test_l2_basic.py
@@ -274,7 +274,7 @@ def test_l2_lag(npu, dataplane):
     # Remove bridge ports
     for idx in range(max_port):
         npu.remove_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[idx])
-        npu.remove(npu.dot1q_bp_oids[idx])
+        npu.remove_bridge_port(npu.dot1q_bp_oids[idx])
 
     # Remove Port #3 from the default VLAN
     npu.remove_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[3])
@@ -360,7 +360,7 @@ def test_l2_lag(npu, dataplane):
         for oid in lag_mbr_oids:
             npu.remove(oid)
 
-        npu.remove(lag_bp_oid)
+        npu.remove_bridge_port(lag_bp_oid)
         npu.remove(lag_oid)
 
         # Create bridge port for ports removed from LAG
@@ -404,7 +404,7 @@ def test_l2_lag_hash_seed(npu, dataplane):
     # Remove bridge ports
     for idx in range(lag_mbr_num):
         npu.remove_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[idx])
-        npu.remove(npu.dot1q_bp_oids[idx])
+        npu.remove_bridge_port(npu.dot1q_bp_oids[idx])
 
     # Remove Port #4 from the default VLAN
     npu.remove_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[lag_mbr_num])
@@ -546,7 +546,7 @@ def test_l2_lag_hash_seed(npu, dataplane):
         for oid in lag_mbr_oids:
             npu.remove(oid)
 
-        npu.remove(lag_bp_oid)
+        npu.remove_bridge_port(lag_bp_oid)
         npu.remove(lag_oid)
 
         # Create bridge port for ports removed from LAG

--- a/tests/ut/test_lag_ut.py
+++ b/tests/ut/test_lag_ut.py
@@ -43,7 +43,7 @@ class TestLag:
         # Remove bridge ports
         for idx in range(TestLag.lag_mbr_num):
             npu.remove_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[idx])
-            npu.remove(npu.dot1q_bp_oids[idx])
+            npu.remove_bridge_port(npu.dot1q_bp_oids[idx])
 
         # Create LAG members
         for idx in range(TestLag.lag_mbr_num):

--- a/topologies/dc_t1.py
+++ b/topologies/dc_t1.py
@@ -38,7 +38,7 @@ def config(npu):
     for oid in dot1q_mbr_oids:
         bp_type = npu.get(oid, ["SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT"]).value()
         if bp_type == "SAI_BRIDGE_PORT_TYPE_PORT":
-            npu.remove(oid)
+            npu.remove_bridge_port(oid)
     npu.dot1q_bp_oids.clear()
 
     # Create default routes

--- a/topologies/sai_ptf_topology.py
+++ b/topologies/sai_ptf_topology.py
@@ -146,7 +146,7 @@ class SaiPtfTopologyMixin:
         """Remove default 1Q bridge ports."""
         for idx in list(range(len(self.npu.port_oids))):
             bp = self.npu.dot1q_bp_oids[idx]
-            self.npu.remove(bp)
+            self.npu.remove_bridge_port(bp)
 
     def remove_default_vlan_members(self) -> None:
         """Detach all ports from the default VLAN and save them for later restore."""
@@ -313,7 +313,7 @@ class SaiPtfTopologyMixin:
     def destroy_bridge_ports(self) -> None:
         """Remove bridge ports in reverse creation order."""
         for bridge_port in reversed(self.def_bridge_port_list):
-            self.npu.remove(bridge_port)
+            self.npu.remove_bridge_port(bridge_port)
         self.def_bridge_port_list.clear()
 
     def destroy_lags_with_members(self) -> None:


### PR DESCRIPTION
Correct bridge port removal process by adding new method to SaiNpu. Replace old bridge port removal with new one in tests, topologies

SAI requires the following (comment from SAI_BRIDGE_PORT_ATTR_ADMIN_STATE attribute):
```c
    /**
     * @brief Admin Mode.
     *
     * Before removing a bridge port, need to disable it by setting admin mode
     * to false, then flush the FDB entries, and then remove it.
     *
     * @type bool
     * @flags CREATE_AND_SET
     * @default false
     */
    SAI_BRIDGE_PORT_ATTR_ADMIN_STATE
```
New method flushes only dynamic FDB entries