### PR TITLE
Add l2 l3 topology layout

### DIFF
--- a/tests/native/test_fdb.py
+++ b/tests/native/test_fdb.py
@@ -39,7 +39,7 @@ def skip_all(testbed_instance):
 def register_topology(npu, topology):
     npu._topo = topology
     npu._topo_initialized = False
-    npu._topo.setup()
+    npu._topo.setup("l2_advanced")
     yield
     npu._topo.teardown()
  
@@ -48,7 +48,7 @@ def on_prev_test_failure(prev_test_failed, npu):
     if prev_test_failed:
         npu.reset()
         npu._topo_initialized = False
-        npu._topo.setup()
+        npu._topo.setup(npu._topo.layout)
 
 def _sai_wait_fdb_age(timeout_sec):
     """Match sai_base_test.SaiHelper.saiWaitFdbAge (sleep timeout + 10s buffer)."""

--- a/tests/native/test_fdb.py
+++ b/tests/native/test_fdb.py
@@ -48,7 +48,7 @@ def on_prev_test_failure(prev_test_failed, npu):
     if prev_test_failed:
         npu.reset()
         npu._topo_initialized = False
-        npu._topo.setup(npu._topo.layout)
+        npu._topo.setup()
 
 def _sai_wait_fdb_age(timeout_sec):
     """Match sai_base_test.SaiHelper.saiWaitFdbAge (sleep timeout + 10s buffer)."""

--- a/tests/native/test_route.py
+++ b/tests/native/test_route.py
@@ -49,7 +49,7 @@ def on_prev_test_failure(prev_test_failed, npu):
     if prev_test_failed:
         npu.reset()
         npu._topo_initialized = False
-        npu._topo.setup(npu._topo.layout)
+        npu._topo.setup()
         
 class TestMultipleRoutes:
     """

--- a/tests/native/test_route.py
+++ b/tests/native/test_route.py
@@ -40,7 +40,7 @@ def skip_all(testbed_instance):
 def register_topology(npu, topology):
     npu._topo = topology
     npu._topo_initialized = False
-    npu._topo.setup()
+    npu._topo.setup("l3_advanced")
     yield
     npu._topo.teardown()
  
@@ -49,7 +49,7 @@ def on_prev_test_failure(prev_test_failed, npu):
     if prev_test_failed:
         npu.reset()
         npu._topo_initialized = False
-        npu._topo.setup()
+        npu._topo.setup(npu._topo.layout)
         
 class TestMultipleRoutes:
     """

--- a/tests/native/test_vlan.py
+++ b/tests/native/test_vlan.py
@@ -52,7 +52,7 @@ def on_prev_test_failure(prev_test_failed, npu):
     if prev_test_failed:
         npu.reset()
         npu._topo_initialized = False
-        npu._topo.setup(npu._topo.layout)
+        npu._topo.setup()
 
 
 def _vlan_data(vlan_id, ports, untagged, large_port):

--- a/tests/native/test_vlan.py
+++ b/tests/native/test_vlan.py
@@ -43,7 +43,7 @@ def skip_all(testbed_instance):
 def register_topology(npu, topology):
     npu._topo = topology
     npu._topo_initialized = False
-    npu._topo.setup()
+    npu._topo.setup("l2_advanced")
     yield
     npu._topo.teardown()
  
@@ -52,7 +52,7 @@ def on_prev_test_failure(prev_test_failed, npu):
     if prev_test_failed:
         npu.reset()
         npu._topo_initialized = False
-        npu._topo.setup()
+        npu._topo.setup(npu._topo.layout)
 
 
 def _vlan_data(vlan_id, ports, untagged, large_port):

--- a/topologies/sai_ptf_topology.py
+++ b/topologies/sai_ptf_topology.py
@@ -113,9 +113,11 @@ class SaiPtfTopologyMixin:
 
     def __init__(self, npu: Any) -> None:
         self.npu = npu
+        self.layout = "l3_advanced"
 
-    def setup(self, layout="l3_advanced") -> None:
-        """Bring up topology for ``layout`` (default ``l3_advanced``)."""
+    def setup(self, layout=None) -> None:
+        if layout is None:
+            layout = self.layout
         if layout not in self.LAYOUTS:
             raise ValueError(f"topology layout must be one of {self.LAYOUTS}, got {layout}")
         self.layout = layout

--- a/topologies/sai_ptf_topology.py
+++ b/topologies/sai_ptf_topology.py
@@ -22,7 +22,20 @@ Quick reference - attribute mapping:
 | ``self.dataplane``        | pytest fixture ``dataplane``                     |
 +---------------------------+--------------------------------------------------+
 
-Ports configuration (U/T = untagged/tagged VLAN member):
+Layouts:
+
++-----------------+------------------------------------------------------------+
+| Layout          | Objects created                                            |
++=================+============================================================+
+| ``l2_basic``    | BP 0–3, VLAN 10/20 (ports only), PVIDs                     |
+| ``l2_advanced`` | ``l2_basic`` + lag1/lag2 in VLAN 10/20                     |
+| ``l3_basic``    | ``l2_advanced`` + port10–13 RIFs, default drop routes      |
+| ``l3_advanced`` | ``l3_basic`` + lag3/4 RIFs, VLAN 30 / lag5 SVI             |
++-----------------+------------------------------------------------------------+
+
+Ports configuration (U/T = untagged/tagged VLAN member).
+Rows from port4 apply from ``l2_advanced``; port10 RIFs from ``l3_basic``;
+lag3+ / VLAN 30 from ``l3_advanced``:
 
 +--------+------+-----------+-------------+--------+------------+------------+
 | Port   | LAG  | _member   | Bridge port | VLAN   | _member    | RIF        |
@@ -89,6 +102,8 @@ class SaiPtfTopologyMixin:
     (port0, lag1, vlan10, port10_rif, ...) so test code stays readable.
     """
 
+    LAYOUTS = ("l2_basic", "l2_advanced", "l3_basic", "l3_advanced")
+
     npu: Any
     switch_id: str
     default_vrf: str
@@ -99,9 +114,11 @@ class SaiPtfTopologyMixin:
     def __init__(self, npu: Any) -> None:
         self.npu = npu
 
-    def setup(self) -> None:
-        """Initialize NPU reference, build aliases and bring up the full topology."""
-
+    def setup(self, layout="l3_advanced") -> None:
+        """Bring up topology for ``layout`` (default ``l3_advanced``)."""
+        if layout not in self.LAYOUTS:
+            raise ValueError(f"topology layout must be one of {self.LAYOUTS}, got {layout}")
+        self.layout = layout
         self.def_bridge_port_list = []
         self.def_lag_list = []
         self.def_lag_member_list = []
@@ -131,10 +148,12 @@ class SaiPtfTopologyMixin:
     def teardown(self) -> None:
         """Tear down topology in the correct SAI order and restore default VLAN state."""
         self.npu.set(self.port2, ["SAI_PORT_ATTR_PORT_VLAN_ID", "0"])
-        self.npu.set(self.lag1, ["SAI_LAG_ATTR_PORT_VLAN_ID", "0"])
         self.npu.set(self.port0, ["SAI_PORT_ATTR_PORT_VLAN_ID", "0"])
+        if self.layout != "l2_basic":
+            self.npu.set(self.lag1, ["SAI_LAG_ATTR_PORT_VLAN_ID", "0"])
 
-        self.destroy_default_routes()
+        if self.layout in ("l3_basic", "l3_advanced"):
+            self.destroy_default_routes()
         self.destroy_routing_interfaces()
         self.destroy_vlans_with_members()
         self.destroy_bridge_ports()
@@ -364,20 +383,12 @@ class SaiPtfTopologyMixin:
 
     def create_sai_helper_topology(self) -> None:
         """Build the full port/VLAN/LAG/RIF layout as described in the module docstring."""
-        self.create_bridge_ports([0, 1, 2, 3, 20, 21])
-
-        self.create_lag_with_members(1, [4, 5, 6])
-        self.create_lag_with_members(2, [7, 8, 9])
-        self.create_lag_with_members(3, [14, 15, 16])
-        self.create_lag_with_members(4, [17, 18, 19])
-        self.create_lag_with_members(5, [22, 23])
-
+        self.create_bridge_ports([0, 1, 2, 3])
         self.create_vlan_with_members(
             10,
             {
                 self.port0_bp: "untagged",
                 self.port1_bp: "tagged",
-                self.lag1_bp: "untagged",
             },
         )
         self.create_vlan_with_members(
@@ -385,9 +396,42 @@ class SaiPtfTopologyMixin:
             {
                 self.port2_bp: "untagged",
                 self.port3_bp: "tagged",
-                self.lag2_bp: "untagged",
             },
         )
+        self.npu.set(self.port0, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
+        self.npu.set(self.port2, ["SAI_PORT_ATTR_PORT_VLAN_ID", "20"])
+        if self.layout == "l2_basic":
+            return
+
+        self.create_lag_with_members(1, [4, 5, 6])
+        self.create_lag_with_members(2, [7, 8, 9])
+        self.vlan10_member2 = self.npu.create_vlan_member(
+            self.vlan10, self.lag1_bp, self._tagging_mode("untagged")
+        )
+        self.vlan20_member2 = self.npu.create_vlan_member(
+            self.vlan20, self.lag2_bp, self._tagging_mode("untagged")
+        )
+        self.def_vlan_member_list.extend([self.vlan10_member2, self.vlan20_member2])
+        self.npu.set(self.lag1, ["SAI_LAG_ATTR_PORT_VLAN_ID", "10"])
+        if self.layout == "l2_advanced":
+            return
+
+        self.create_routing_interfaces(
+            [
+                {"type": "port", "port_or_vlan": 10},
+                {"type": "port", "port_or_vlan": 11},
+                {"type": "port", "port_or_vlan": 12},
+                {"type": "port", "port_or_vlan": 13},
+            ]
+        )
+        self.create_default_routes()
+        if self.layout == "l3_basic":
+            return
+
+        self.create_bridge_ports([20, 21])
+        self.create_lag_with_members(3, [14, 15, 16])
+        self.create_lag_with_members(4, [17, 18, 19])
+        self.create_lag_with_members(5, [22, 23])
         self.create_vlan_with_members(
             30,
             {
@@ -396,24 +440,13 @@ class SaiPtfTopologyMixin:
                 self.lag5_bp: "untagged",
             },
         )
-
-        self.npu.set(self.port0, ["SAI_PORT_ATTR_PORT_VLAN_ID", "10"])
-        self.npu.set(self.lag1, ["SAI_LAG_ATTR_PORT_VLAN_ID", "10"])
-        self.npu.set(self.port2, ["SAI_PORT_ATTR_PORT_VLAN_ID", "20"])
-
         self.create_routing_interfaces(
             [
                 {"type": "vlan", "port_or_vlan": 30},
                 {"type": "lag", "port_or_vlan": 3},
                 {"type": "lag", "port_or_vlan": 4},
-                {"type": "port", "port_or_vlan": 10},
-                {"type": "port", "port_or_vlan": 11},
-                {"type": "port", "port_or_vlan": 12},
-                {"type": "port", "port_or_vlan": 13},
             ]
         )
-
-        self.create_default_routes()
 
     def _cpu_queue(self, idx=0):
         """Retrieves the CPU QoS queue OID at the specified index (default is 0)."""


### PR DESCRIPTION
## Summary
- Shared PTF helper topology always created LAG RIFs, VLAN 30, and default drop routes, even for L2-only tests.
- `setup(layout=...)` now builds a prefix of that helper: `l2_basic` → `l2_advanced` → `l3_basic` → `l3_advanced` (default).
### Wired three native modules as the first users:
  `test_vlan.py` / `test_fdb.py` → `l2_advanced` (VLAN 10/20 + lag1/lag2, no RIFs)
   `test_route.py` → `l3_advanced` (same full helper as before, including `lag4_rif` / SVI)
After `npu.reset()`, fixtures call `setup(npu._topo.layout)` so the same layout is rebuilt.

# Run tests
```
./exec.sh --no-tty pytest --testbed=saivs_standalone -s -v   native/test_route.py   native/test_fdb.py   native/test_vlan.py
```

```
native/test_route.py::TestMultipleRoutes::test_multiple_routes_forward PASSED
native/test_route.py::TestDropRoute::test_drop_route PASSED
native/test_route.py::TestRouteUpdate::test_route_update PASSED
native/test_route.py::TestRouteIngressRif::test_route_ingress_rif PASSED
native/test_route.py::TestEmptyEcmpGroup::test_empty_ecmp_group PASSED
native/test_route.py::TestSviNeighbor::test_svi_neighbor PASSED
native/test_route.py::TestCpuForward::test_cpu_forward PASSED
native/test_route.py::TestRemoveAddNeighbor::test_remove_add_neighbor PASSED
native/test_route.py::TestRouteNeighborCollision::test_route_neighbor_collision PASSED
native/test_route.py::TestDirBcastGleanAndForward::test_directed_broadcast_glean_and_forward PASSED
native/test_route.py::TestDirBcastForward::test_directed_broadcast_forward PASSED
native/test_fdb.py::TestFdbStaticMac::test_fdb_static_mac_forward SKIPPED
native/test_fdb.py::TestFdbStaticMac::test_fdb_self_forwarding_drop SKIPPED
native/test_fdb.py::TestFdbAttribute::test_fdb_attribute PASSED
native/test_fdb.py::TestFdbNoLearn::test_vlan_port_no_learn SKIPPED
native/test_fdb.py::TestFdbNoLearn::test_vlan_lag_no_learn SKIPPED (...)
native/test_fdb.py::TestFdbNoLearn::test_bp_port_no_learn SKIPPED (T...)
native/test_fdb.py::TestFdbNoLearn::test_bp_lag_no_learn SKIPPED (Tr...)
native/test_fdb.py::TestFdbNoLearn::test_removed_bp_no_learn SKIPPED
native/test_fdb.py::TestFdbNoLearn::test_no_bp_no_learn SKIPPED (The...)
native/test_fdb.py::TestFdbLearn::test_dynamic_mac_learn SKIPPED (Tr...)
native/test_fdb.py::TestFdbLearn::test_mac_learn_error SKIPPED (Traf...)
native/test_fdb.py::TestFdbMacMove::test_dynamic_mac_move SKIPPED (T...)
native/test_fdb.py::TestFdbMacMove::test_dynamic_mac_move_static_entry SKIPPED
native/test_fdb.py::TestFdbMacMove::test_static_mac_move SKIPPED (Tr...)
native/test_fdb.py::TestFdbFlush::test_flush_static_per_vlan SKIPPED
native/test_fdb.py::TestFdbFlush::test_flush_dynamic_per_vlan SKIPPED
native/test_fdb.py::TestFdbFlush::test_flush_all_per_vlan SKIPPED (T...)
native/test_fdb.py::TestFdbFlush::test_flush_static_per_port SKIPPED
native/test_fdb.py::TestFdbFlush::test_flush_dynamic_per_port SKIPPED
native/test_fdb.py::TestFdbFlush::test_flush_all_per_port SKIPPED (T...)
native/test_fdb.py::TestFdbFlush::test_flush_static_per_lag SKIPPED
native/test_fdb.py::TestFdbFlush::test_flush_dynamic_per_lag SKIPPED
native/test_fdb.py::TestFdbFlush::test_flush_all_per_lag SKIPPED (Tr...)
native/test_fdb.py::TestFdbFlush::test_flush_static_per_vlan_and_port SKIPPED
native/test_fdb.py::TestFdbFlush::test_flush_dynamic_per_vlan_and_port SKIPPED
native/test_fdb.py::TestFdbFlush::test_flush_all_per_vlan_and_port SKIPPED
native/test_fdb.py::TestFdbFlush::test_flush_all_static SKIPPED (Tra...)
native/test_fdb.py::TestFdbFlush::test_flush_all_dynamic SKIPPED (Tr...)
native/test_fdb.py::TestFdbFlush::test_flush_all_macs SKIPPED (Traff...)
native/test_fdb.py::TestFdbAge::test_mac_aging_on_port SKIPPED (Traf...)
native/test_fdb.py::TestFdbAge::test_mac_aging_on_lag SKIPPED (Traff...)
native/test_fdb.py::TestFdbAge::test_mac_aging_after_move SKIPPED (T...)
native/test_fdb.py::TestFdbAge::test_mac_move_after_aging SKIPPED (T...)
native/test_fdb.py::TestFdbMiss::test_unicast_miss_drop_action SKIPPED
native/test_fdb.py::TestFdbMiss::test_unicast_miss_copy_action SKIPPED
native/test_fdb.py::TestFdbMiss::test_unicast_miss_trap_action SKIPPED
native/test_fdb.py::TestFdbMiss::test_multicast_miss_drop_action SKIPPED
native/test_fdb.py::TestFdbMiss::test_multicast_miss_copy_action SKIPPED
native/test_fdb.py::TestFdbMiss::test_multicast_miss_trap_action SKIPPED
native/test_fdb.py::TestFdbMiss::test_broadcast_miss_drop_action SKIPPED
native/test_fdb.py::TestFdbMiss::test_broadcast_miss_copy_action SKIPPED
native/test_fdb.py::TestFdbMiss::test_broadcast_miss_trap_action SKIPPED
native/test_fdb.py::TestFdbEvent::test_mac_learn_event SKIPPED (Traf...)
native/test_fdb.py::TestFdbEvent::test_mac_age_event SKIPPED (Traffi...)
native/test_fdb.py::TestFdbEvent::test_mac_move_event SKIPPED (Traff...)
native/test_fdb.py::TestFdbEvent::test_mac_flush_event SKIPPED (Traf...)
native/test_fdb.py::TestFdbEvent::test_mac_delete_event SKIPPED (Tra...)
native/test_vlan.py::TestL2Vlan::test_forwarding SKIPPED (Traffic ge...)
native/test_vlan.py::TestL2Vlan::test_native_vlan SKIPPED (Traffic g...)
native/test_vlan.py::TestL2Vlan::test_priority_tagging SKIPPED (Traf...)
native/test_vlan.py::TestL2Vlan::test_pv_drop SKIPPED (Traffic gener...)
native/test_vlan.py::TestL2Vlan::test_lag_pv_miss SKIPPED (Traffic g...)
native/test_vlan.py::TestL2Vlan::test_vlan_flood SKIPPED (Traffic ge...)
native/test_vlan.py::TestL2Vlan::test_vlan_flood_enhanced SKIPPED (T...)
native/test_vlan.py::TestL2Vlan::test_vlan_flood_disable SKIPPED (Tr...)
native/test_vlan.py::TestL2Vlan::test_vlan_stats SKIPPED (Traffic ge...)
native/test_vlan.py::TestL2Vlan::test_vlan_flood_prune SKIPPED (Traf...)
native/test_vlan.py::TestL2Vlan::test_counters_clear SKIPPED (Traffi...)
native/test_vlan.py::TestL2Vlan::test_vlan_member_list PASSED
native/test_vlan.py::TestL2Vlan::test_vlan_negative PASSED
native/test_vlan.py::TestL2Vlan::test_single_vlan_member SKIPPED (Tr...)
native/test_vlan.py::TestL2Vlan::test_vlan_ingress_acl SKIPPED (Traf...)
native/test_vlan.py::TestL2Vlan::test_vlan_egress_acl SKIPPED (Traff...)
native/test_vlan.py::TestL2Vlan::test_vlan_learning SKIPPED (Traffic...)
native/test_vlan.py::TestL2Vlan::test_vlan_max_learned_addresses SKIPPED
```